### PR TITLE
feat: premium portfolio refresh

### DIFF
--- a/docs/plans/2026-04-14-premium-portfolio-refresh.md
+++ b/docs/plans/2026-04-14-premium-portfolio-refresh.md
@@ -1,0 +1,621 @@
+# Premium Portfolio Refresh Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Rebuild the portfolio into a premium, hiring-focused, SEO-strong, agent-discoverable multi-page site with clean routing, stronger conversion paths, and a temporary palette preview system.
+
+**Architecture:** Convert the current mixed homepage-plus-duplicate-pages structure into a canonical multi-page information architecture. Centralize metadata, sitemap generation, redirects, theme tokens, and `llms.txt` generation so the visual refresh, SEO improvements, and agent-readable profile all derive from the same source-of-truth data and route model.
+
+**Tech Stack:** Next.js App Router, React 19, TypeScript, Tailwind CSS, Framer Motion, JSON content files, ESLint
+
+---
+
+### Task 1: Baseline Verification And Route Inventory
+
+**Files:**
+- Modify: none
+- Test: existing route/build/lint commands
+
+**Step 1: Record current route/build state**
+
+Run: `npm run build`
+Expected: build succeeds and prints the current route table.
+
+**Step 2: Record current lint state**
+
+Run: `npm run lint`
+Expected: fail on the known `ThemeContext` rule so the cleanup work has a clear baseline.
+
+**Step 3: Record current branch state**
+
+Run: `git status --short --branch`
+Expected: only the plan file is untracked or modified before implementation begins.
+
+**Step 4: Commit the planning doc**
+
+```bash
+git add docs/plans/2026-04-14-premium-portfolio-refresh.md
+git commit -m "docs: add premium portfolio refresh plan"
+```
+
+### Task 2: Establish The New Route Model
+
+**Files:**
+- Modify: `next.config.js`
+- Modify: `src/app/page.tsx`
+- Modify: `src/app/work/page.tsx`
+- Modify: `src/app/work/[company]/page.tsx`
+- Modify: `src/app/work/complianceos/page.tsx`
+- Create: `src/app/experience/page.tsx`
+- Create: `src/app/experience/[company]/page.tsx`
+- Create: `src/app/case-studies/[slug]/page.tsx`
+- Test: `npm run build`
+
+**Step 1: Write the failing route expectations**
+
+Create a lightweight route verification checklist in the plan execution notes or test notes before changing code:
+- `/experience` should replace `/work`
+- `/experience/[company]` should replace `/work/[company]`
+- `/case-studies/complianceos` should replace `/work/complianceos`
+- old URLs should redirect permanently
+
+**Step 2: Run build to confirm current route table does not match the target**
+
+Run: `npm run build`
+Expected: existing route table still shows `/work` and `/work/complianceos`, confirming the target behavior does not exist yet.
+
+**Step 3: Add route redirects in `next.config.js`**
+
+Implement permanent redirects:
+
+```js
+{
+  source: "/work",
+  destination: "/experience",
+  permanent: true,
+}
+{
+  source: "/work/:company",
+  destination: "/experience/:company",
+  permanent: true,
+}
+{
+  source: "/work/complianceos",
+  destination: "/case-studies/complianceos",
+  permanent: true,
+}
+```
+
+Order the redirects so the specific case-study redirect wins before the generic company redirect.
+
+**Step 4: Create the new canonical pages**
+
+Implement:
+- `src/app/experience/page.tsx` by adapting the current work index page
+- `src/app/experience/[company]/page.tsx` by adapting the current company page
+- `src/app/case-studies/[slug]/page.tsx` by generalizing the current ComplianceOS deep dive
+
+Start minimal: support only `complianceos` from `work.json` in the new case-study route.
+
+**Step 5: Reduce the old route pages to redirect-only surfaces or remove them if safe**
+
+Prefer simple server redirects from the old app routes so both Next.js routing and `next.config.js` agree on canonical destinations.
+
+**Step 6: Verify the new route table**
+
+Run: `npm run build`
+Expected: build succeeds and shows `/experience`, `/experience/[company]`, and `/case-studies/[slug]` as canonical app routes.
+
+**Step 7: Commit**
+
+```bash
+git add next.config.js src/app/page.tsx src/app/work/page.tsx src/app/work/[company]/page.tsx src/app/work/complianceos/page.tsx src/app/experience/page.tsx src/app/experience/[company]/page.tsx src/app/case-studies/[slug]/page.tsx
+git commit -m "feat: normalize portfolio route structure"
+```
+
+### Task 3: Centralize SEO Metadata And Canonicals
+
+**Files:**
+- Modify: `src/app/layout.tsx`
+- Modify: `src/app/about/page.tsx`
+- Modify: `src/app/contact/page.tsx`
+- Modify: `src/app/projects/page.tsx`
+- Modify: `src/app/publications/page.tsx`
+- Modify: `src/app/page.tsx`
+- Modify: `src/app/experience/page.tsx`
+- Modify: `src/app/experience/[company]/page.tsx`
+- Modify: `src/app/case-studies/[slug]/page.tsx`
+- Modify: `src/lib/profile.ts`
+- Create: `src/lib/metadata.ts`
+- Test: `npm run build`
+
+**Step 1: Write the failing metadata expectation list**
+
+Target every canonical page to have:
+- title
+- description
+- canonical URL
+- Open Graph
+- Twitter card
+- page-specific structured data where appropriate
+
+**Step 2: Confirm the current helper does not exist**
+
+Run: `npm run build`
+Expected: no centralized metadata helper is in use yet; page metadata remains repetitive.
+
+**Step 3: Create `src/lib/metadata.ts`**
+
+Add a minimal shared helper layer such as:
+
+```ts
+import type { Metadata } from "next";
+
+export function buildPageMetadata({
+  title,
+  description,
+  path,
+  type = "website",
+}: {
+  title: string;
+  description: string;
+  path: string;
+  type?: "website" | "profile" | "article";
+}): Metadata {
+  // derive canonical, openGraph, twitter from one source
+}
+```
+
+**Step 4: Apply the helper across page files**
+
+Replace repetitive inline metadata blocks with helper calls. Keep page-specific details only where necessary.
+
+**Step 5: Strengthen layout metadata**
+
+Add site-level defaults in `layout.tsx`:
+- metadata title template
+- default Open Graph image if one exists later
+- Twitter summary card defaults
+- alternates where useful
+
+**Step 6: Extend structured data intentionally**
+
+Use `src/lib/profile.ts` for:
+- homepage `Person` + `WebSite`
+- experience/company pages as profile or article-like pages only if accurate
+- case studies as `Article` or `CreativeWork`
+- publications as `ScholarlyArticle` list items
+
+**Step 7: Verify metadata build safety**
+
+Run: `npm run build`
+Expected: build succeeds with no metadata type errors.
+
+**Step 8: Commit**
+
+```bash
+git add src/app/layout.tsx src/app/about/page.tsx src/app/contact/page.tsx src/app/projects/page.tsx src/app/publications/page.tsx src/app/page.tsx src/app/experience/page.tsx src/app/experience/[company]/page.tsx src/app/case-studies/[slug]/page.tsx src/lib/profile.ts src/lib/metadata.ts
+git commit -m "feat: centralize metadata and canonical seo"
+```
+
+### Task 4: Rebuild Sitemap, Robots, And `llms.txt`
+
+**Files:**
+- Modify: `src/app/sitemap.ts`
+- Modify: `src/app/robots.ts`
+- Modify: `src/app/llms.txt/route.ts`
+- Modify: `src/app/llm.txt/route.ts`
+- Modify: `src/lib/profile.ts`
+- Modify: `src/data/contact.json`
+- Modify: `src/data/hero.json`
+- Test: `npm run build`
+
+**Step 1: Write the failing content expectation**
+
+The final `llms.txt` should include:
+- identity
+- positioning
+- availability
+- booking link
+- resume link
+- canonical page URLs
+- featured case studies
+- projects
+- publications
+- provenance instructions
+
+**Step 2: Verify current output is incomplete**
+
+Run: `npm run build`
+Expected: current `llms.txt` output is generated, but it does not yet reflect the new route taxonomy or richer dossier fields.
+
+**Step 3: Update `hero.json` and `contact.json` source data**
+
+Add source-of-truth fields needed for the dossier and conversion surfaces, such as:
+- `bookingUrl`
+- `resumeUrl`
+- refined positioning text
+- availability copy
+
+**Step 4: Update `buildLlmProfileText` in `src/lib/profile.ts`**
+
+Add sections for:
+- preferred roles
+- availability
+- booking link
+- canonical URL map
+- featured experience pages
+- featured case studies
+
+Keep the style factual and compact.
+
+**Step 5: Rebuild sitemap from canonical pages only**
+
+Update `src/app/sitemap.ts` to emit:
+- `/`
+- `/about`
+- `/contact`
+- `/projects`
+- `/publications`
+- `/experience`
+- `/experience/[company]`
+- `/case-studies/[slug]`
+- `/llms.txt`
+
+Do not include replaced `/work` pages.
+
+**Step 6: Keep `robots.ts` aligned**
+
+Ensure the host and sitemap point to the canonical site URL and sitemap path.
+
+**Step 7: Verify route generation**
+
+Run: `npm run build`
+Expected: build succeeds and the route table includes the `llms.txt` surfaces without SEO inconsistencies.
+
+**Step 8: Commit**
+
+```bash
+git add src/app/sitemap.ts src/app/robots.ts src/app/llms.txt/route.ts src/app/llm.txt/route.ts src/lib/profile.ts src/data/contact.json src/data/hero.json
+git commit -m "feat: improve sitemap and llms profile output"
+```
+
+### Task 5: Fix Theme State Architecture Before UI Refresh
+
+**Files:**
+- Modify: `src/app/context/ThemeContext.tsx`
+- Modify: `src/app/layout.tsx`
+- Test: `npm run lint`
+
+**Step 1: Write the failing verification**
+
+Run: `npm run lint`
+Expected: fail on `react-hooks/set-state-in-effect` in `ThemeContext.tsx`.
+
+**Step 2: Replace effect-driven initialization with lazy state**
+
+Refactor `ThemeContext` toward:
+
+```ts
+const [theme, setTheme] = useState<"light" | "dark">(() => {
+  if (typeof window === "undefined") return "dark";
+  return localStorage.getItem("theme") === "light" ? "light" : "dark";
+});
+```
+
+Then use effects only for:
+- syncing DOM classes
+- persisting to localStorage
+
+**Step 3: Prevent hydration flicker intentionally**
+
+Add a tiny inline theme script in `layout.tsx` if necessary so the initial theme class is applied before hydration.
+
+**Step 4: Verify the lint fix**
+
+Run: `npm run lint`
+Expected: no `ThemeContext` lint error remains.
+
+**Step 5: Commit**
+
+```bash
+git add src/app/context/ThemeContext.tsx src/app/layout.tsx
+git commit -m "fix: stabilize theme initialization"
+```
+
+### Task 6: Build A Semantic Theme Token System And Palette Preview Mode
+
+**Files:**
+- Modify: `src/app/globals.css`
+- Modify: `src/app/context/ThemeContext.tsx`
+- Modify: `src/app/components/ui/ThemeToggle.tsx`
+- Create: `src/app/components/ui/ThemePreviewPanel.tsx`
+- Create: `src/lib/themes.ts`
+- Test: `npm run lint`
+
+**Step 1: Write the failing theme preview expectation**
+
+The site should support:
+- dark mode and light mode
+- multiple palette families during preview
+- one semantic token layer feeding all UI colors
+
+**Step 2: Confirm current CSS tokens are single-palette only**
+
+Read `globals.css` and verify the current root tokens only represent one brand family.
+
+**Step 3: Create `src/lib/themes.ts`**
+
+Define preview theme families using semantic token maps. Include all candidate palette families from the user shortlist as named presets.
+
+Suggested shape:
+
+```ts
+export const themeFamilies = {
+  blueGoldClassic: { ... },
+  blueGoldModern: { ... },
+  metallicGold: { ... },
+  champagne: { ... },
+};
+```
+
+Each family should expose both light and dark values.
+
+**Step 4: Apply the tokens in CSS**
+
+Move hardcoded palette values in `globals.css` to semantic CSS variables for:
+- background
+- surface
+- surface-muted
+- text-primary
+- text-secondary
+- border
+- accent-primary
+- accent-secondary
+- glow
+- ring
+
+**Step 5: Add temporary preview controls**
+
+Implement `ThemePreviewPanel.tsx` so you can switch palette families locally on the real site. Keep it obviously temporary and easy to remove later.
+
+**Step 6: Integrate preview state with the existing theme context**
+
+Persist:
+- dark/light mode
+- selected preview palette
+
+**Step 7: Verify styles and lint**
+
+Run: `npm run lint`
+Expected: theme preview code and token refactor pass lint.
+
+**Step 8: Commit**
+
+```bash
+git add src/app/globals.css src/app/context/ThemeContext.tsx src/app/components/ui/ThemeToggle.tsx src/app/components/ui/ThemePreviewPanel.tsx src/lib/themes.ts
+git commit -m "feat: add premium theme tokens and palette preview"
+```
+
+### Task 7: Redesign The Navigation For Conversion And Page Flow
+
+**Files:**
+- Modify: `src/app/components/Navbar.tsx`
+- Modify: `src/data/hero.json`
+- Modify: `src/data/contact.json`
+- Test: `npm run lint`
+
+**Step 1: Write the failing nav expectation**
+
+The final nav should contain:
+- `Home`
+- `Experience`
+- `Projects`
+- `About`
+- `Contact`
+- visible utility actions for `Resume` and `Book a call`
+
+**Step 2: Confirm current nav still uses old route assumptions**
+
+Read `Navbar.tsx` and verify it still points to `/work`, homepage anchors, and the external `Links` item.
+
+**Step 3: Replace the nav model**
+
+Update nav links to the new canonical routes and remove the generic `Links` item.
+
+**Step 4: Add utility actions**
+
+Use `resumeUrl` and `bookingUrl` from source data to render:
+- secondary resume link
+- primary booking CTA
+
+**Step 5: Preserve mobile usability**
+
+Ensure both actions remain visible and easy to tap in the mobile menu.
+
+**Step 6: Verify lint**
+
+Run: `npm run lint`
+Expected: the updated nav passes lint.
+
+**Step 7: Commit**
+
+```bash
+git add src/app/components/Navbar.tsx src/data/hero.json src/data/contact.json
+git commit -m "feat: redesign navigation for conversion"
+```
+
+### Task 8: Rebuild The Homepage As A Short Premium Landing Page
+
+**Files:**
+- Modify: `src/app/page.tsx`
+- Modify: `src/app/components/Hero.tsx`
+- Modify: `src/app/components/Experience.tsx`
+- Modify: `src/app/components/Projects.tsx`
+- Modify: `src/app/components/About.tsx`
+- Modify: `src/app/components/Contact.tsx`
+- Create: `src/app/components/home/FeaturedExperience.tsx`
+- Create: `src/app/components/home/FeaturedProjects.tsx`
+- Create: `src/app/components/home/ValueSection.tsx`
+- Create: `src/app/components/home/CtaSection.tsx`
+- Test: `npm run build`
+
+**Step 1: Write the failing homepage expectation**
+
+The homepage should become a short landing page with:
+- calm luxurious hero
+- featured experience cards
+- featured projects or case studies
+- short value section
+- CTA section
+
+It should no longer duplicate the full About, Experience, Projects, and Contact pages.
+
+**Step 2: Confirm current homepage is still long-form**
+
+Run: `npm run build`
+Expected: homepage still renders all major sections from the old one-page model.
+
+**Step 3: Rewrite `Hero.tsx`**
+
+Change hero behavior to:
+- editorial serif-led headline
+- current image treated as a premium portrait stand-in
+- `Book a call` primary CTA
+- `View selected work` secondary CTA
+- quieter resume link
+
+**Step 4: Create homepage-only section components**
+
+Implement small focused components for the landing page instead of reusing full-page sections with `showTopBorder={false}` hacks.
+
+**Step 5: Keep visitors moving naturally**
+
+Each homepage block should have a next-step CTA:
+- featured experience -> `View all experience`
+- featured projects -> `See all projects`
+- CTA band -> `Book a call`, `Contact`, `Resume`
+
+**Step 6: Verify the new homepage compiles cleanly**
+
+Run: `npm run build`
+Expected: build succeeds and homepage remains static.
+
+**Step 7: Commit**
+
+```bash
+git add src/app/page.tsx src/app/components/Hero.tsx src/app/components/Experience.tsx src/app/components/Projects.tsx src/app/components/About.tsx src/app/components/Contact.tsx src/app/components/home/FeaturedExperience.tsx src/app/components/home/FeaturedProjects.tsx src/app/components/home/ValueSection.tsx src/app/components/home/CtaSection.tsx
+git commit -m "feat: rebuild homepage as premium landing page"
+```
+
+### Task 9: Refresh Core Page Designs With The Premium System
+
+**Files:**
+- Modify: `src/app/about/page.tsx`
+- Modify: `src/app/contact/page.tsx`
+- Modify: `src/app/projects/page.tsx`
+- Modify: `src/app/publications/page.tsx`
+- Modify: `src/app/experience/page.tsx`
+- Modify: `src/app/experience/[company]/page.tsx`
+- Modify: `src/app/case-studies/[slug]/page.tsx`
+- Modify: `src/app/components/Footer.tsx`
+- Test: `npm run build`
+
+**Step 1: Write the failing page-design expectation**
+
+Each page should feel premium, calmer, and more editorial while still fitting one shared system.
+
+**Step 2: Update page-level layouts**
+
+Apply:
+- stronger headings
+- better spacing rhythm
+- reduced card repetition
+- clearer CTA endings
+- better section hierarchy
+
+**Step 3: Make Contact a higher-conversion page**
+
+Ensure the contact page leads with:
+- availability statement
+- booking CTA
+- email/direct links
+- resume link
+- contact form below
+
+**Step 4: Improve projects and experience scanning**
+
+Give cards stronger outcome framing and more obvious next actions.
+
+**Step 5: Keep publications secondary**
+
+Retain quality but reduce navigation prominence and visual dominance.
+
+**Step 6: Verify the full site build**
+
+Run: `npm run build`
+Expected: all redesigned pages compile successfully.
+
+**Step 7: Commit**
+
+```bash
+git add src/app/about/page.tsx src/app/contact/page.tsx src/app/projects/page.tsx src/app/publications/page.tsx src/app/experience/page.tsx src/app/experience/[company]/page.tsx src/app/case-studies/[slug]/page.tsx src/app/components/Footer.tsx
+git commit -m "feat: refresh portfolio pages with premium layouts"
+```
+
+### Task 10: Final Verification And Cleanup
+
+**Files:**
+- Modify: any files required by verification failures
+- Test: full verification commands
+
+**Step 1: Run lint**
+
+Run: `npm run lint`
+Expected: PASS.
+
+**Step 2: Run production build**
+
+Run: `npm run build`
+Expected: PASS with the final route table.
+
+**Step 3: Manually verify key URLs in dev**
+
+Run: `npm run dev`
+
+Check in browser:
+- `/`
+- `/experience`
+- `/experience/onfinance-ai`
+- `/projects`
+- `/case-studies/complianceos`
+- `/about`
+- `/contact`
+- `/publications`
+- `/llms.txt`
+- legacy `/work` URL redirect
+
+**Step 4: Validate the final user flows**
+
+Confirm:
+- nav CTA visibility
+- booking link works
+- resume link works
+- homepage naturally points deeper into the site
+- palette preview works for comparison
+
+**Step 5: Commit final fixes**
+
+```bash
+git add .
+git commit -m "feat: complete premium portfolio refresh"
+```
+
+**Step 6: Prepare for review**
+
+Before opening a PR, summarize:
+- route changes
+- SEO changes
+- `llms.txt` changes
+- theming changes
+- conversion changes

--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,21 @@ const nextConfig = {
         destination: "/work/:path*",
         permanent: true,
       },
+      {
+        source: "/work/complianceos",
+        destination: "/case-studies/complianceos",
+        permanent: true,
+      },
+      {
+        source: "/work/:company",
+        destination: "/experience/:company",
+        permanent: true,
+      },
+      {
+        source: "/work",
+        destination: "/experience",
+        permanent: true,
+      },
     ];
   },
   images: {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,21 +5,15 @@ import Navbar from "@/app/components/Navbar";
 import Footer from "@/app/components/Footer";
 import About from "@/app/components/About";
 import { ThemeToggle } from "@/app/components/ui/ThemeToggle";
+import { buildPageMetadata } from "@/lib/metadata";
+import Link from "next/link";
 
-const title = `About | ${heroData.name}`;
-const description = aboutData.description?.primary || heroData.shortDescription;
-
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: { canonical: "/about" },
-  openGraph: {
-    title,
-    description,
-    url: "/about",
-    type: "profile",
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: "About",
+  description: aboutData.description?.primary || heroData.shortDescription,
+  path: "/about",
+  type: "profile",
+});
 
 export default function AboutPage() {
   return (
@@ -28,11 +22,18 @@ export default function AboutPage() {
       className="flex min-h-screen flex-col bg-background transition-colors duration-300"
     >
       <Navbar />
-      <h1 className="sr-only">
-        About {heroData.name} — Backend systems & LLM tooling engineer
-      </h1>
       <div className="pt-24">
         <About showTopBorder={false} />
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-12 border-t border-text-tertiary/10">
+          <div className="flex flex-wrap gap-3">
+            <Link href="/contact" className="btn btn-primary">
+              Get in touch
+            </Link>
+            <Link href="/experience" className="btn btn-secondary">
+              View experience
+            </Link>
+          </div>
+        </div>
       </div>
       <Footer />
       <ThemeToggle />

--- a/src/app/case-studies/[slug]/page.tsx
+++ b/src/app/case-studies/[slug]/page.tsx
@@ -1,0 +1,237 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Script from "next/script";
+import heroData from "@/data/hero.json";
+import workData from "@/data/work.json";
+import Navbar from "@/app/components/Navbar";
+import Footer from "@/app/components/Footer";
+import { ThemeToggle } from "@/app/components/ui/ThemeToggle";
+import { getSiteUrl } from "@/lib/profile";
+
+export function generateStaticParams() {
+  return workData.work.map((item) => ({ slug: item.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const workItem = workData.work.find((item) => item.slug === slug);
+
+  const pagePath = `/case-studies/${slug}`;
+  const title = workItem
+    ? `${workItem.title} — End-to-end Work | ${heroData.name}`
+    : `Case Study | ${heroData.name}`;
+  const description = workItem
+    ? workItem.summary.join(" ")
+    : "A detailed case study of end-to-end engineering work.";
+
+  return {
+    title,
+    description,
+    alternates: { canonical: pagePath },
+    openGraph: {
+      title,
+      description,
+      url: pagePath,
+      type: "article",
+    },
+  };
+}
+
+export default async function CaseStudyPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const workItem = workData.work.find((item) => item.slug === slug);
+  const pagePath = `/case-studies/${slug}`;
+
+  if (!workItem) {
+    return (
+      <main className="min-h-screen bg-background">
+        <Navbar />
+        <div className="container mt-24 mx-auto px-4 sm:px-8 md:px-12 py-12">
+          <h1 className="text-2xl font-semibold tracking-tight text-text-primary">
+            Work not found
+          </h1>
+          <p className="mt-4 text-text-secondary">
+            This page is missing. Go back to{" "}
+            <Link href="/experience" className="link-underline text-text-primary">
+              experience
+            </Link>
+            .
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const siteUrl = getSiteUrl();
+  const pageUrl = `${siteUrl}${pagePath}`;
+  const title = `${workItem.title} — End-to-end Work | ${heroData.name}`;
+  const description = workItem.summary.join(" ");
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": `${pageUrl}#webpage`,
+    url: pageUrl,
+    name: title,
+    description,
+    about: [
+      {
+        "@type": "CreativeWork",
+        "@id": `${pageUrl}#work`,
+        name: workItem.title,
+        description: workItem.summary.join(" "),
+        url: pageUrl,
+        creator: {
+          "@type": "Person",
+          name: heroData.name,
+          url: siteUrl,
+        },
+        publisher: {
+          "@type": "Organization",
+          name: workItem.company.name,
+          url: workItem.company.url,
+        },
+        keywords: workItem.stack || [],
+        inLanguage: "en",
+      },
+    ],
+  };
+
+  return (
+    <main
+      id="content"
+      className="flex min-h-screen flex-col bg-background transition-colors duration-300"
+    >
+      <Script
+        id={`${slug}-jsonld`}
+        type="application/ld+json"
+        strategy="beforeInteractive"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Navbar />
+      <div className="container mt-24 mx-auto px-4 sm:px-8 md:px-12 py-12">
+        <div className="mb-10">
+          <div className="font-mono text-xs uppercase tracking-widest text-text-tertiary">
+            <Link href="/" className="hover:text-primary transition-colors">
+              Home
+            </Link>{" "}
+            <span className="mx-2">/</span>
+            <Link
+              href="/experience"
+              className="hover:text-primary transition-colors"
+            >
+              Case Studies
+            </Link>{" "}
+            <span className="mx-2">/</span>
+            <span className="text-primary">{workItem.title}</span>
+          </div>
+
+          <h1 className="mt-6 text-4xl sm:text-5xl font-semibold tracking-tight text-text-primary">
+            {workItem.title}
+          </h1>
+          <p className="mt-4 text-text-secondary text-base sm:text-lg max-w-3xl leading-relaxed">
+            {workItem.subtitle}
+          </p>
+        </div>
+
+        <section aria-labelledby="key-facts" className="surface-card p-6 sm:p-8 mb-10">
+          <h2 id="key-facts" className="pill w-fit">Key facts</h2>
+          <dl className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <dt className="font-mono text-xs uppercase tracking-widest text-text-tertiary">Role</dt>
+              <dd className="mt-2 text-text-primary">{workItem.role}</dd>
+            </div>
+            <div>
+              <dt className="font-mono text-xs uppercase tracking-widest text-text-tertiary">Company</dt>
+              <dd className="mt-2">
+                <a href={workItem.company.url} target="_blank" rel="noopener noreferrer" className="link-underline text-text-primary">
+                  {workItem.company.name}
+                </a>
+              </dd>
+            </div>
+            <div>
+              <dt className="font-mono text-xs uppercase tracking-widest text-text-tertiary">Base</dt>
+              <dd className="mt-2 text-text-primary">{workItem.location}</dd>
+            </div>
+            <div>
+              <dt className="font-mono text-xs uppercase tracking-widest text-text-tertiary">Open_To</dt>
+              <dd className="mt-2 text-text-primary">{workItem.openness}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section aria-labelledby="summary" className="mb-12">
+          <h2 id="summary" className="text-2xl font-semibold tracking-tight text-text-primary">Summary</h2>
+          <div className="mt-4 space-y-4 text-text-secondary leading-relaxed">
+            {workItem.summary.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </div>
+        </section>
+
+        <section aria-labelledby="highlights" className="mb-12">
+          <h2 id="highlights" className="text-2xl font-semibold tracking-tight text-text-primary">Highlights</h2>
+          <ul className="mt-4 space-y-3 text-text-secondary">
+            {workItem.highlights.map((item) => (
+              <li key={item} className="flex gap-3">
+                <span className="text-primary opacity-60">•</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section aria-labelledby="stack" className="mb-12">
+          <h2 id="stack" className="text-2xl font-semibold tracking-tight text-text-primary">Stack</h2>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {workItem.stack.map((item) => (
+              <span key={item} className="pill">{item}</span>
+            ))}
+          </div>
+        </section>
+
+        <section aria-labelledby="evidence" className="mb-12">
+          <h2 id="evidence" className="text-2xl font-semibold tracking-tight text-text-primary">Evidence</h2>
+          <ul className="mt-4 space-y-3 text-text-secondary">
+            {workItem.links.map((link) => (
+              <li key={link.url}>
+                <a href={link.url} target="_blank" rel="noopener noreferrer" className="link-underline text-text-primary">
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section aria-labelledby="notes" className="surface-card p-6 sm:p-8">
+          <h2 id="notes" className="pill w-fit">Notes</h2>
+          <ul className="mt-4 space-y-3 text-text-secondary text-sm">
+            {workItem.notes.map((note) => (
+              <li key={note} className="flex gap-3">
+                <span className="text-primary opacity-60">•</span>
+                <span>{note}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <Link href="/experience" className="btn btn-secondary">
+              Back to experience
+            </Link>
+            <Link href="/contact" className="btn btn-primary">Contact</Link>
+          </div>
+        </section>
+      </div>
+
+      <Footer />
+      <ThemeToggle />
+    </main>
+  );
+}

--- a/src/app/components/Contact.tsx
+++ b/src/app/components/Contact.tsx
@@ -2,7 +2,7 @@
 import React, { FC, useId, useState } from "react";
 import Link from "next/link";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faGithub, faLinkedin } from "@fortawesome/free-brands-svg-icons";
+import { faGithub, faLinkedin, faXTwitter } from "@fortawesome/free-brands-svg-icons";
 import emailjs from "@emailjs/browser";
 import DOMPurify from "dompurify";
 import { motion } from "framer-motion";
@@ -201,7 +201,13 @@ const Contact: FC<{ showTopBorder?: boolean }> = ({ showTopBorder = true }) => {
                   >
                     <span className="sr-only">{social.platform}</span>
                     <FontAwesomeIcon
-                      icon={social.icon === "faGithub" ? faGithub : faLinkedin}
+                      icon={
+                        social.icon === "faGithub"
+                          ? faGithub
+                          : social.icon === "faXTwitter"
+                            ? faXTwitter
+                            : faLinkedin
+                      }
                       className="h-5 w-5"
                     />
                     <span className="capitalize">{social.platform}</span>

--- a/src/app/components/Experience.tsx
+++ b/src/app/components/Experience.tsx
@@ -115,7 +115,7 @@ export default function Experience({
 
                 <div className="flex flex-col gap-3 w-full lg:w-[320px]">
                   <Link
-                    href={`/work/${entry.slug}`}
+                    href={`/experience/${entry.slug}`}
                     className="btn btn-primary"
                   >
                     View experience
@@ -157,7 +157,7 @@ export default function Experience({
 
         {showSeeMore && (
           <div className="mt-10">
-            <Link href="/work" className="btn btn-secondary">
+            <Link href="/experience" className="btn btn-secondary">
               See full experience timeline
             </Link>
           </div>

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -4,54 +4,105 @@ import Link from "next/link";
 import contactData from "@/data/contact.json";
 
 const Footer: React.FC = () => {
-  const github = contactData.socialMedia?.find(
-    (item) => item.platform === "github",
-  )?.url;
-  const linkedin = contactData.socialMedia?.find(
-    (item) => item.platform === "linkedin",
-  )?.url;
+  const github = contactData.socialMedia?.find((item) => item.platform === "github")?.url;
+  const twitter = contactData.socialMedia?.find((item) => item.platform === "twitter")?.url;
+  const linkedin = contactData.socialMedia?.find((item) => item.platform === "linkedin")?.url;
+  const bookingUrl = (contactData as any).bookingUrl as string | undefined;
+  const resumeUrl = (contactData as any).resumeUrl as string | undefined;
 
   return (
-    <footer className="bg-background text-text-tertiary border-t border-text-tertiary/20 py-10">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 flex flex-col md:flex-row justify-between items-start gap-6">
-        <div>
-          <div className="text-text-primary font-semibold tracking-tight">
-            Krishnatejaswi Shenthar
+    <footer className="bg-background border-t border-text-tertiary/20 py-10">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6">
+        <div className="flex flex-col md:flex-row justify-between items-start gap-8">
+          {/* Left: identity */}
+          <div className="flex-shrink-0">
+            <div className="text-text-primary font-semibold tracking-tight">
+              Krishnatejaswi Shenthar
+            </div>
+            <div className="mt-1 text-xs font-mono uppercase tracking-widest text-text-tertiary">
+              Backend · Distributed · LLM tooling
+            </div>
+            <div className="mt-3 text-sm text-text-secondary max-w-[32ch]">
+              Built with Next.js. Designed to communicate engineering craft and
+              outcomes.
+            </div>
           </div>
-          <div className="mt-1 text-xs font-mono uppercase tracking-widest text-text-tertiary">
-            Backend · Distributed · LLM tooling
-          </div>
-          <div className="mt-3 text-sm text-text-secondary">
-            Built with Next.js. Designed to communicate engineering craft and
-            outcomes.
-          </div>
+
+          {/* Middle: site nav */}
+          <nav
+            aria-label="Footer navigation"
+            className="flex flex-col gap-2 text-sm"
+          >
+          <span className="text-xs font-mono uppercase tracking-widest text-text-tertiary mb-1">
+              Pages
+            </span>
+            <Link href="/experience" className="text-text-secondary hover:text-text-primary transition-colors">
+              Experience
+            </Link>
+            <Link href="/projects" className="text-text-secondary hover:text-text-primary transition-colors">
+              Projects
+            </Link>
+            <Link href="/about" className="text-text-secondary hover:text-text-primary transition-colors">
+              About
+            </Link>
+            <Link href="/contact" className="text-text-secondary hover:text-text-primary transition-colors">
+              Contact
+            </Link>
+            <Link href="/publications" className="text-text-secondary hover:text-text-primary transition-colors">
+              Publications
+            </Link>
+          </nav>
+
+          {/* Right: social + utility */}
+          <nav
+            aria-label="Footer links"
+            className="flex flex-wrap gap-3"
+          >
+            {github && (
+              <Link href={github} target="_blank" rel="noopener noreferrer" className="btn btn-secondary">
+                GitHub
+              </Link>
+            )}
+            {twitter && (
+              <Link href={twitter} target="_blank" rel="noopener noreferrer" className="btn btn-secondary">
+                Twitter
+              </Link>
+            )}
+            {linkedin && (
+              <Link href={linkedin} target="_blank" rel="noopener noreferrer" className="btn btn-secondary">
+                LinkedIn
+              </Link>
+            )}
+            <a href={`mailto:${contactData.email}`} className="btn btn-secondary">
+              Email
+            </a>
+            {resumeUrl && (
+              <a
+                href={resumeUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-secondary"
+              >
+                Resume ↗
+              </a>
+            )}
+            {bookingUrl && (
+              <a
+                href={bookingUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-primary"
+              >
+                Book a call
+              </a>
+            )}
+          </nav>
         </div>
 
-        <nav aria-label="Footer links" className="flex flex-wrap gap-3">
-          {github && (
-            <Link
-              href={github}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="btn btn-secondary"
-            >
-              GitHub
-            </Link>
-          )}
-          {linkedin && (
-            <Link
-              href={linkedin}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="btn btn-secondary"
-            >
-              LinkedIn
-            </Link>
-          )}
-          <a href={`mailto:${contactData.email}`} className="btn btn-primary">
-            Email
-          </a>
-        </nav>
+        {/* Bottom copyright row */}
+        <div className="mt-8 pt-6 border-t border-text-tertiary/10 text-xs text-text-tertiary">
+          © {new Date().getFullYear()} Krishnatejaswi Shenthar
+        </div>
       </div>
     </footer>
   );

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -6,6 +6,9 @@ import Link from "next/link";
 import heroData from "@/data/hero.json";
 
 const Hero: FC = () => {
+  const bookingUrl = (heroData as any).bookingUrl as string;
+  const resumeUrl = (heroData as any).resumeUrl as string;
+
   return (
     <section
       id="home"
@@ -38,32 +41,30 @@ const Hero: FC = () => {
               </p>
 
               <div className="mt-8 flex flex-wrap gap-3">
-                {heroData.buttons.map((button) => {
-                  const className =
-                    button.type === "primary"
-                      ? "btn btn-primary"
-                      : "btn btn-secondary";
+                {/* Primary CTA */}
+                <a
+                  href={bookingUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-primary"
+                >
+                  Book a call
+                </a>
 
-                  return button.external ? (
-                    <Link
-                      key={button.text}
-                      href={button.link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={className}
-                    >
-                      {button.text}
-                    </Link>
-                  ) : (
-                    <a
-                      key={button.text}
-                      href={button.link}
-                      className={className}
-                    >
-                      {button.text}
-                    </a>
-                  );
-                })}
+                {/* Secondary CTA */}
+                <Link href="/projects" className="btn btn-secondary">
+                  View selected work
+                </Link>
+
+                {/* Resume CTA */}
+                <a
+                  href={resumeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-secondary"
+                >
+                  Resume ↗
+                </a>
               </div>
             </motion.div>
 
@@ -145,4 +146,5 @@ const Hero: FC = () => {
     </section>
   );
 };
+
 export default Hero;

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -5,102 +5,39 @@ import { usePathname } from "next/navigation";
 import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/solid";
 import heroData from "@/data/hero.json";
 
-interface NAVLINK {
+interface NavLink {
   title: string;
-  homePath: string;
   routePath: string;
-  external?: boolean;
 }
 
-const navLinks: NAVLINK[] = [
-  {
-    title: "Home",
-    homePath: "#home",
-    routePath: "/",
-  },
-  {
-    title: "Experience",
-    homePath: "#experience",
-    routePath: "/work",
-  },
-  {
-    title: "Projects",
-    homePath: "#projects",
-    routePath: "/projects",
-  },
-  {
-    title: "Writing",
-    homePath: "/publications",
-    routePath: "/publications",
-  },
-  {
-    title: "About",
-    homePath: "#about",
-    routePath: "/about",
-  },
-  {
-    title: "Contact",
-    homePath: "#contact",
-    routePath: "/contact",
-  },
-  {
-    title: "Links",
-    homePath: "https://kts-o7.github.io/",
-    routePath: "https://kts-o7.github.io/",
-    external: true,
-  },
+const navLinks: NavLink[] = [
+  { title: "Home", routePath: "/" },
+  { title: "Experience", routePath: "/experience" },
+  { title: "Projects", routePath: "/projects" },
+  { title: "About", routePath: "/about" },
+  { title: "Contact", routePath: "/contact" },
 ];
+
+const bookingUrl = (heroData as any).bookingUrl as string;
+const resumeUrl = (heroData as any).resumeUrl as string;
 
 const Navbar: FC = () => {
   const [navbarOpen, setIsOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
-  const [activeSection, setActiveSection] = useState("home");
   const pathname = usePathname();
-  const isHome = pathname === "/";
 
   useEffect(() => {
     const handleScroll = () => {
       setScrolled(window.scrollY > 50);
     };
-
     window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
-    if (!isHome) {
-      return () => {
-        window.removeEventListener("scroll", handleScroll);
-      };
-    }
-
-    // Intersection Observer for active section highlighting (home page only)
-    const observerOptions = {
-      root: null,
-      rootMargin: "-100px 0px -60% 0px",
-      threshold: 0,
-    };
-
-    const observerCallback = (entries: IntersectionObserverEntry[]) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          setActiveSection(entry.target.id);
-        }
-      });
-    };
-
-    const observer = new IntersectionObserver(
-      observerCallback,
-      observerOptions,
-    );
-    const sections = ["home", "experience", "projects", "about", "contact"];
-    sections.forEach((id) => {
-      const el = document.getElementById(id);
-      if (el) observer.observe(el);
-    });
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-      observer.disconnect();
-    };
-  }, [isHome]);
+  const isActive = (routePath: string) => {
+    if (routePath === "/") return pathname === "/";
+    return pathname === routePath || pathname.startsWith(routePath + "/");
+  };
 
   return (
     <>
@@ -117,7 +54,8 @@ const Navbar: FC = () => {
         aria-label="Main Navigation"
       >
         <div className="max-w-7xl mx-auto flex items-center justify-between px-4 sm:px-6 py-3 sm:py-4">
-          <Link href={"/"} className="group flex items-baseline gap-3">
+          {/* Logo */}
+          <Link href="/" className="group flex items-baseline gap-3">
             <span className="inline-flex items-center justify-center h-9 w-9 rounded-full border border-text-tertiary/30 bg-surface/60 text-text-primary font-semibold">
               K
             </span>
@@ -131,6 +69,7 @@ const Navbar: FC = () => {
             </span>
           </Link>
 
+          {/* Mobile toggle */}
           <div className="md:hidden">
             <button
               onClick={() => setIsOpen(!navbarOpen)}
@@ -138,43 +77,49 @@ const Navbar: FC = () => {
               aria-label={navbarOpen ? "Close menu" : "Open menu"}
               aria-expanded={navbarOpen}
             >
-              {!navbarOpen ? (
-                <Bars3Icon className="h-6 w-6 sm:h-7 sm:w-7" />
-              ) : (
+              {navbarOpen ? (
                 <XMarkIcon className="h-6 w-6 sm:h-7 sm:w-7" />
+              ) : (
+                <Bars3Icon className="h-6 w-6 sm:h-7 sm:w-7" />
               )}
             </button>
           </div>
 
-          <div className="hidden md:flex md:items-center space-x-7">
-            {navLinks.map((link, index) => {
-              const href = isHome ? link.homePath : link.routePath;
+          {/* Desktop nav */}
+          <div className="hidden md:flex md:items-center gap-6">
+            {navLinks.map((link) => (
+              <Link
+                key={link.routePath}
+                href={link.routePath}
+                className={`font-mono text-xs uppercase tracking-widest transition-colors link-underline ${
+                  isActive(link.routePath)
+                    ? "text-text-primary"
+                    : "text-text-secondary hover:text-text-primary"
+                }`}
+                aria-current={isActive(link.routePath) ? "page" : undefined}
+              >
+                {link.title}
+              </Link>
+            ))}
 
-              const isAnchor = href.startsWith("#");
-              const isActive = isHome
-                ? isAnchor && activeSection === href.substring(1)
-                : !link.external &&
-                  (href === pathname ||
-                    (href === "/work" && pathname.startsWith("/work")) ||
-                    (href === "/projects" && pathname.startsWith("/projects")));
-
-              return (
-                <Link
-                  key={index}
-                  href={href}
-                  target={link.external ? "_blank" : undefined}
-                  rel={link.external ? "noopener noreferrer" : undefined}
-                  className={`font-mono text-xs uppercase tracking-widest transition-colors link-underline ${
-                    isActive
-                      ? "text-text-primary"
-                      : "text-text-secondary hover:text-text-primary"
-                  }`}
-                  aria-current={isActive ? "page" : undefined}
-                >
-                  {link.title}
-                </Link>
-              );
-            })}
+            <div className="flex items-center gap-2 ml-2">
+              <a
+                href={resumeUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-secondary text-xs py-1.5 px-3"
+              >
+                Resume
+              </a>
+              <a
+                href={bookingUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-primary text-xs py-1.5 px-3"
+              >
+                Book a call
+              </a>
+            </div>
           </div>
         </div>
 
@@ -182,21 +127,42 @@ const Navbar: FC = () => {
         {navbarOpen && (
           <div className="md:hidden animate-fadeIn">
             <div className="px-3 sm:px-4 py-2 sm:py-3 space-y-1.5 sm:space-y-2 bg-background border-b border-text-tertiary/25">
-              {navLinks.map((link, index) => {
-                const href = isHome ? link.homePath : link.routePath;
-                return (
-                  <Link
-                    key={index}
-                    href={href}
-                    target={link.external ? "_blank" : undefined}
-                    rel={link.external ? "noopener noreferrer" : undefined}
-                    className="block py-3 px-3 sm:px-4 text-text-secondary hover:bg-surface hover:text-text-primary font-mono text-sm transition-all duration-300 mobile-touch-optimized min-h-[44px] flex items-center uppercase tracking-wider"
-                    onClick={() => setIsOpen(false)}
-                  >
-                    {link.title}
-                  </Link>
-                );
-              })}
+              {navLinks.map((link) => (
+                <Link
+                  key={link.routePath}
+                  href={link.routePath}
+                  className={`block py-3 px-3 sm:px-4 font-mono text-sm transition-all duration-300 mobile-touch-optimized min-h-[44px] flex items-center uppercase tracking-wider ${
+                    isActive(link.routePath)
+                      ? "text-text-primary bg-surface"
+                      : "text-text-secondary hover:bg-surface hover:text-text-primary"
+                  }`}
+                  aria-current={isActive(link.routePath) ? "page" : undefined}
+                  onClick={() => setIsOpen(false)}
+                >
+                  {link.title}
+                </Link>
+              ))}
+
+              <div className="flex gap-2 pt-2 px-3">
+                <a
+                  href={resumeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-secondary text-sm flex-1 text-center"
+                  onClick={() => setIsOpen(false)}
+                >
+                  Resume
+                </a>
+                <a
+                  href={bookingUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-primary text-sm flex-1 text-center"
+                  onClick={() => setIsOpen(false)}
+                >
+                  Book a call
+                </a>
+              </div>
             </div>
           </div>
         )}

--- a/src/app/components/home/CtaSection.tsx
+++ b/src/app/components/home/CtaSection.tsx
@@ -1,0 +1,47 @@
+"use client";
+import React from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import heroData from "@/data/hero.json";
+
+export default function CtaSection() {
+  const bookingUrl = (heroData as any).bookingUrl as string;
+  const resumeUrl = (heroData as any).resumeUrl as string;
+
+  return (
+    <section className="bg-background py-20 sm:py-28 border-t border-text-tertiary/10">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 text-center">
+        <motion.div initial={{ opacity: 0, y: 10 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }}>
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-semibold tracking-tight text-text-primary">
+            Let&apos;s build something reliable.
+          </h2>
+          <p className="mt-4 text-text-secondary max-w-[60ch] mx-auto leading-relaxed">
+            Available for full-time roles and select freelance projects. Based in Bangalore — open to remote.
+          </p>
+
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <a
+              href={bookingUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn btn-primary"
+            >
+              Book a call
+            </a>
+            <Link href="/contact" className="btn btn-secondary">
+              Send a message
+            </Link>
+            <a
+              href={resumeUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn btn-secondary"
+            >
+              Resume ↗
+            </a>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/components/home/FeaturedExperience.tsx
+++ b/src/app/components/home/FeaturedExperience.tsx
@@ -1,0 +1,62 @@
+"use client";
+import React from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import experienceData from "@/data/experience.json";
+
+export default function FeaturedExperience() {
+  const entries = experienceData.experience.slice(0, 2);
+
+  return (
+    <section className="bg-background py-20 sm:py-24 border-t border-text-tertiary/10">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6">
+        <motion.div initial={{ opacity: 0, y: 10 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }}>
+          <span className="pill">Experience</span>
+          <h2 className="mt-5 text-3xl sm:text-4xl font-semibold tracking-tight text-text-primary">
+            Where I&apos;ve shipped
+          </h2>
+        </motion.div>
+
+        <div className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-5">
+          {entries.map((entry, i) => (
+            <motion.article
+              key={entry.slug}
+              initial={{ opacity: 0, y: 12 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.08 }}
+              className="surface-card p-6 flex flex-col justify-between gap-6"
+            >
+              <div>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <h3 className="text-lg font-semibold tracking-tight text-text-primary">{entry.company.name}</h3>
+                  {entry.type && <span className="pill">{entry.type}</span>}
+                </div>
+                <p className="mt-1 text-text-secondary text-sm">{entry.role} · {entry.timeframe}</p>
+                {entry.summary && (
+                  <p className="mt-3 text-text-secondary text-sm leading-relaxed line-clamp-3">{entry.summary}</p>
+                )}
+                {entry.skills && (
+                  <div className="mt-4 flex flex-wrap gap-1.5">
+                    {entry.skills.slice(0, 5).map((s) => (
+                      <span key={s} className="pill text-[11px]">{s}</span>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <Link href={`/experience/${entry.slug}`} className="btn btn-secondary text-sm w-fit">
+                View details →
+              </Link>
+            </motion.article>
+          ))}
+        </div>
+
+        <div className="mt-8">
+          <Link href="/experience" className="btn btn-secondary">
+            View all experience →
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/components/home/FeaturedProjects.tsx
+++ b/src/app/components/home/FeaturedProjects.tsx
@@ -1,0 +1,72 @@
+"use client";
+import React from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import projectsData from "@/data/projects.json";
+
+export default function FeaturedProjects() {
+  const projects = projectsData.projects
+    .filter((p) => !p.tag.includes("Publication"))
+    .slice(0, 3);
+
+  return (
+    <section className="bg-background py-20 sm:py-24 border-t border-text-tertiary/10">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6">
+        <motion.div initial={{ opacity: 0, y: 10 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }}>
+          <span className="pill">Selected work</span>
+          <h2 className="mt-5 text-3xl sm:text-4xl font-semibold tracking-tight text-text-primary">
+            Projects that show how I think
+          </h2>
+        </motion.div>
+
+        <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-5">
+          {projects.map((project, i) => {
+            const url =
+              (project.links as any)?.demo ||
+              (project.links as any)?.paper ||
+              (project.links as any)?.source ||
+              project.link;
+            return (
+              <motion.article
+                key={project.id}
+                initial={{ opacity: 0, y: 12 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: i * 0.08 }}
+                className="surface-card p-6 flex flex-col justify-between gap-5"
+              >
+                <div>
+                  <h3 className="text-base font-semibold tracking-tight text-text-primary">{project.name}</h3>
+                  <p className="mt-2 text-text-secondary text-sm leading-relaxed line-clamp-4">{project.description}</p>
+                  {project.tech && (
+                    <div className="mt-4 flex flex-wrap gap-1.5">
+                      {project.tech.slice(0, 4).map((t) => (
+                        <span key={t} className="pill text-[11px]">{t}</span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                {url && (
+                  <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn btn-secondary text-sm w-fit"
+                  >
+                    View →
+                  </a>
+                )}
+              </motion.article>
+            );
+          })}
+        </div>
+
+        <div className="mt-8">
+          <Link href="/projects" className="btn btn-secondary">
+            See all projects →
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/components/home/ValueSection.tsx
+++ b/src/app/components/home/ValueSection.tsx
@@ -1,0 +1,49 @@
+"use client";
+import React from "react";
+import { motion } from "framer-motion";
+
+const values = [
+  {
+    label: "Backend-first",
+    body: "APIs, distributed systems, and data pipelines built for production — observable, reliable, fast.",
+  },
+  {
+    label: "LLM tooling",
+    body: "RAG pipelines, agentic workflows, evals, and LiteLLM orchestration over real regulatory-scale corpora.",
+  },
+  {
+    label: "End-to-end ownership",
+    body: "From schema design to k8s deployment. I ship things that stay up.",
+  },
+];
+
+export default function ValueSection() {
+  return (
+    <section className="bg-background py-20 sm:py-24 border-t border-text-tertiary/10">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6">
+        <motion.div initial={{ opacity: 0, y: 10 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }}>
+          <span className="pill">Why work with me</span>
+          <h2 className="mt-5 text-3xl sm:text-4xl font-semibold tracking-tight text-text-primary">
+            What I bring to a team
+          </h2>
+        </motion.div>
+
+        <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-5">
+          {values.map((v, i) => (
+            <motion.div
+              key={v.label}
+              initial={{ opacity: 0, y: 12 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.08 }}
+              className="surface-card p-6"
+            >
+              <h3 className="font-mono text-xs uppercase tracking-widest text-text-tertiary">{v.label}</h3>
+              <p className="mt-3 text-text-secondary leading-relaxed">{v.body}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/components/ui/ThemePreviewPanel.tsx
+++ b/src/app/components/ui/ThemePreviewPanel.tsx
@@ -1,0 +1,59 @@
+"use client";
+import React, { useState } from "react";
+import { useTheme } from "@/app/context/ThemeContext";
+import { paletteLabels, themePalettes } from "@/lib/themes";
+
+export const ThemePreviewPanel = () => {
+  const { palette, setPalette, theme } = useTheme();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="fixed bottom-20 left-4 z-50">
+      {!open ? (
+        <button
+          onClick={() => setOpen(true)}
+          className="px-3 py-1.5 rounded-full border border-text-tertiary/30 bg-surface/80 backdrop-blur text-xs font-mono uppercase tracking-wider text-text-secondary hover:text-text-primary transition-all"
+        >
+          Palettes
+        </button>
+      ) : (
+        <div className="surface-card p-3 w-56 max-h-80 overflow-y-auto no-scrollbar">
+          <div className="flex items-center justify-between mb-2">
+            <span className="font-mono text-xs uppercase tracking-widest text-text-tertiary">
+              Palette
+            </span>
+            <button
+              onClick={() => setOpen(false)}
+              className="text-text-tertiary hover:text-text-primary text-xs"
+            >
+              ✕
+            </button>
+          </div>
+          <div className="space-y-1">
+            {Object.entries(paletteLabels).map(([key, label]) => {
+              const tokens =
+                themePalettes[key]?.[theme === "light" ? "light" : "dark"];
+              return (
+                <button
+                  key={key}
+                  onClick={() => setPalette(key)}
+                  className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-left text-xs transition-all ${
+                    palette === key
+                      ? "bg-surface text-text-primary border border-text-tertiary/30"
+                      : "text-text-secondary hover:text-text-primary hover:bg-surface/50"
+                  }`}
+                >
+                  <span
+                    className="w-3 h-3 rounded-full flex-shrink-0 border border-text-tertiary/20"
+                    style={{ backgroundColor: tokens?.primary || "#888" }}
+                  />
+                  <span className="truncate">{label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,34 +5,51 @@ import Navbar from "@/app/components/Navbar";
 import Footer from "@/app/components/Footer";
 import Contact from "@/app/components/Contact";
 import { ThemeToggle } from "@/app/components/ui/ThemeToggle";
+import { buildPageMetadata } from "@/lib/metadata";
 
-const title = `Contact | ${heroData.name}`;
-const description = contactData.description || heroData.shortDescription;
-
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: { canonical: "/contact" },
-  openGraph: {
-    title,
-    description,
-    url: "/contact",
-    type: "website",
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: "Contact",
+  description:
+    (contactData as any).availability ||
+    contactData.description ||
+    heroData.shortDescription,
+  path: "/contact",
+});
 
 export default function ContactPage() {
+  const bookingUrl = (contactData as any).bookingUrl as string;
+
   return (
     <main
       id="content"
       className="flex min-h-screen flex-col bg-background transition-colors duration-300"
     >
       <Navbar />
-      <h1 className="sr-only">Contact {heroData.name}</h1>
-      <div className="pt-24">
-        <Contact showTopBorder={false} />
+      <div className="pt-24 max-w-7xl mx-auto px-4 sm:px-6 w-full">
+        <header className="py-12 border-b border-text-tertiary/10">
+          <span className="pill">Available</span>
+          <h1 className="mt-5 text-4xl sm:text-5xl font-semibold tracking-tight text-text-primary">
+            Let&apos;s work together
+          </h1>
+          <p className="mt-4 text-text-secondary max-w-[60ch] leading-relaxed">
+            {(contactData as any).availability ||
+              "Available for full-time roles and select freelance projects."}
+          </p>
+          {bookingUrl && (
+            <div className="mt-6">
+              <a
+                href={bookingUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-primary"
+              >
+                Book a call
+              </a>
+            </div>
+          )}
+        </header>
       </div>
-
+      <Contact showTopBorder={false} />
       <Footer />
       <ThemeToggle />
     </main>

--- a/src/app/context/ThemeContext.tsx
+++ b/src/app/context/ThemeContext.tsx
@@ -1,42 +1,102 @@
 "use client";
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useSyncExternalStore,
+} from "react";
 
-const ThemeContext = createContext({
+type Theme = "dark" | "light";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  palette: string;
+  setPalette: (key: string) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
   theme: "dark",
   toggleTheme: () => {},
+  palette: "forestPink",
+  setPalette: () => {},
 });
 
 export const useTheme = () => useContext(ThemeContext);
 
-export const ThemeProvider = ({ children }) => {
-  const [theme, setTheme] = useState("dark");
+// ---------------------------------------------------------------------------
+// localStorage-backed external store helpers
+// ---------------------------------------------------------------------------
 
-  useEffect(() => {
-    // Load saved theme after mount
-    const savedTheme = localStorage.getItem("theme");
-    if (savedTheme) {
-      setTheme(savedTheme);
-    }
-  }, []);
+function subscribeToStorage(callback: () => void) {
+  window.addEventListener("storage", callback);
+  return () => window.removeEventListener("storage", callback);
+}
 
+function getThemeSnapshot(): Theme {
+  const val = localStorage.getItem("theme");
+  return val === "light" ? "light" : "dark";
+}
+
+function getThemeServerSnapshot(): Theme {
+  return "dark";
+}
+
+function getPaletteSnapshot(): string {
+  return localStorage.getItem("palette") || "forestPink";
+}
+
+function getPaletteServerSnapshot(): string {
+  return "forestPink";
+}
+
+// ---------------------------------------------------------------------------
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  // useSyncExternalStore is the React-blessed API for reading browser storage.
+  // It always returns the server snapshot during SSR / first-render so the
+  // server and client initial renders agree, eliminating the hydration mismatch.
+  // After hydration it reads the live localStorage value and re-renders once if
+  // it differs — this is safe because it's driven by the store, not setState
+  // inside an effect.
+  const theme = useSyncExternalStore(
+    subscribeToStorage,
+    getThemeSnapshot,
+    getThemeServerSnapshot,
+  );
+
+  const palette = useSyncExternalStore(
+    subscribeToStorage,
+    getPaletteSnapshot,
+    getPaletteServerSnapshot,
+  );
+
+  // Sync DOM classes for theme (pure external side-effect, no setState)
   useEffect(() => {
-    if (theme === "dark") {
-      document.documentElement.classList.add("dark");
-      document.documentElement.classList.remove("light");
-    } else {
-      document.documentElement.classList.add("light");
-      document.documentElement.classList.remove("dark");
-    }
+    const root = document.documentElement;
+    root.classList.remove("dark", "light");
+    root.classList.add(theme);
   }, [theme]);
 
+  // Sync palette data attribute (pure external side-effect, no setState)
+  useEffect(() => {
+    document.documentElement.setAttribute("data-palette", palette);
+  }, [palette]);
+
   const toggleTheme = () => {
-    const newTheme = theme === "dark" ? "light" : "dark";
-    setTheme(newTheme);
-    localStorage.setItem("theme", newTheme);
+    const next: Theme = theme === "dark" ? "light" : "dark";
+    localStorage.setItem("theme", next);
+    // Dispatch a storage event so useSyncExternalStore re-reads the snapshot
+    window.dispatchEvent(new Event("storage"));
+  };
+
+  const setPalette = (key: string) => {
+    localStorage.setItem("palette", key);
+    window.dispatchEvent(new Event("storage"));
   };
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, toggleTheme, palette, setPalette }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/app/experience/[company]/page.tsx
+++ b/src/app/experience/[company]/page.tsx
@@ -1,0 +1,250 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import heroData from "@/data/hero.json";
+import experienceData from "@/data/experience.json";
+import projectsData from "@/data/projects.json";
+import Navbar from "@/app/components/Navbar";
+import Footer from "@/app/components/Footer";
+import { ThemeToggle } from "@/app/components/ui/ThemeToggle";
+
+type ExperienceEntry = {
+  slug: string;
+  company: { name: string; url?: string };
+  role: string;
+  type?: string;
+  location?: string;
+  timeframe?: string;
+  summary?: string;
+  highlights?: string[];
+  skills?: string[];
+  caseStudies?: { title: string; href: string }[];
+  selectedProjectIds?: number[];
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ company: string }>;
+}): Promise<Metadata> {
+  const { company } = await params;
+  const entry = (experienceData.experience as ExperienceEntry[]).find(
+    (item) => item.slug === company,
+  );
+
+  const title = entry
+    ? `${entry.company.name} | Experience | ${heroData.name}`
+    : `Experience | ${heroData.name}`;
+  const description =
+    entry?.summary ||
+    "Work experience, outcomes, and supporting projects grouped by company.";
+
+  return {
+    title,
+    description,
+    alternates: { canonical: `/experience/${company}` },
+    openGraph: {
+      title,
+      description,
+      url: `/experience/${company}`,
+      type: "profile",
+    },
+  };
+}
+
+export default async function CompanyExperiencePage({
+  params,
+}: {
+  params: Promise<{ company: string }>;
+}) {
+  const { company } = await params;
+  const entry = (experienceData.experience as ExperienceEntry[]).find(
+    (item) => item.slug === company,
+  );
+
+  if (!entry) {
+    return (
+      <main id="content" className="min-h-screen bg-background">
+        <Navbar />
+        <div className="container mt-24 mx-auto px-4 sm:px-8 md:px-12 py-12">
+          <h1 className="text-2xl font-semibold tracking-tight text-text-primary">
+            Experience not found
+          </h1>
+          <p className="mt-4 text-text-secondary">
+            This page doesn&apos;t exist. Go back to{" "}
+            <Link href="/experience" className="link-underline text-text-primary">
+              experience
+            </Link>
+            .
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const selectedProjects = (entry.selectedProjectIds || [])
+    .map((id) => projectsData.projects.find((p) => p.id === id))
+    .filter(Boolean);
+
+  return (
+    <main
+      id="content"
+      className="flex min-h-screen flex-col bg-background transition-colors duration-300"
+    >
+      <Navbar />
+      <div className="container mt-24 mx-auto px-4 sm:px-8 md:px-12 py-10">
+        <div className="font-mono text-xs uppercase tracking-widest text-text-tertiary">
+          <Link href="/" className="link-underline text-text-primary">
+            Home
+          </Link>{" "}
+          <span className="mx-2">/</span>
+          <Link href="/experience" className="link-underline text-text-primary">
+            Experience
+          </Link>{" "}
+          <span className="mx-2">/</span>
+          <span className="text-text-secondary">{entry.company.name}</span>
+        </div>
+
+        <header className="mt-6">
+          <span className="pill w-fit">{entry.type || "Experience"}</span>
+          <h1 className="mt-5 text-4xl sm:text-5xl font-semibold tracking-tight text-text-primary">
+            {entry.company.name}
+          </h1>
+          <p className="mt-3 text-text-secondary text-base sm:text-lg leading-relaxed max-w-[72ch]">
+            {entry.role}
+            {entry.timeframe ? ` · ${entry.timeframe}` : ""}
+            {entry.location ? ` · ${entry.location}` : ""}
+          </p>
+          {entry.summary && (
+            <p className="mt-5 text-text-secondary leading-relaxed max-w-[80ch]">
+              {entry.summary}
+            </p>
+          )}
+        </header>
+
+        {Array.isArray(entry.highlights) && entry.highlights.length > 0 && (
+          <section className="mt-10 surface-card p-6 sm:p-8">
+            <h2 className="pill w-fit">Highlights</h2>
+            <ul className="mt-5 space-y-2 text-text-secondary">
+              {entry.highlights.map((item) => (
+                <li key={item} className="flex gap-3 leading-relaxed">
+                  <span className="mt-2 h-1.5 w-1.5 rounded-full bg-primary flex-shrink-0" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {Array.isArray(entry.skills) && entry.skills.length > 0 && (
+          <section className="mt-6 surface-card p-6 sm:p-8">
+            <h2 className="pill w-fit">Stack</h2>
+            <div className="mt-5 flex flex-wrap gap-2">
+              {entry.skills.map((skill) => (
+                <span key={skill} className="pill">
+                  {skill}
+                </span>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {Array.isArray(entry.caseStudies) && entry.caseStudies.length > 0 && (
+          <section className="mt-6 surface-card p-6 sm:p-8">
+            <h2 className="pill w-fit">Case studies</h2>
+            <div className="mt-5 space-y-3">
+              {entry.caseStudies.map((cs) => {
+                const href = cs.href.startsWith("/work/complianceos")
+                  ? "/case-studies/complianceos"
+                  : cs.href;
+                return (
+                  <Link
+                    key={cs.href}
+                    href={href}
+                    className="btn btn-primary w-fit"
+                  >
+                    {cs.title}
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {selectedProjects.length > 0 && (
+          <section className="mt-6 surface-card p-6 sm:p-8">
+            <h2 className="pill w-fit">Selected projects</h2>
+            <ul className="mt-6 space-y-4">
+              {selectedProjects.map((project) => (
+                <li key={project!.id}>
+                  <div className="rounded-[14px] border border-[var(--border)] p-5">
+                    <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                      <div>
+                        <div className="text-lg font-semibold tracking-tight text-text-primary">
+                          {project!.name}
+                        </div>
+                        <div className="mt-2 text-text-secondary leading-relaxed">
+                          {project!.description}
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {(project!.tech || []).slice(0, 6).map((t: string) => (
+                          <span key={t} className="pill">
+                            {t}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="mt-4 flex flex-wrap gap-3">
+                      {(project!.links?.demo || project!.links?.paper) && (
+                        <a
+                          href={project!.links?.demo || project!.links?.paper}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="btn btn-primary"
+                        >
+                          Open
+                        </a>
+                      )}
+                      <a
+                        href={project!.links?.source || project!.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-secondary"
+                      >
+                        Source
+                      </a>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <section className="mt-10">
+          <div className="flex flex-wrap gap-3">
+            <Link href="/experience" className="btn btn-secondary">
+              Back to experience
+            </Link>
+            {entry.company?.url && (
+              <a
+                href={entry.company.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-secondary"
+              >
+                Company site
+              </a>
+            )}
+            <Link href="/contact" className="btn btn-primary">
+              Contact
+            </Link>
+          </div>
+        </section>
+      </div>
+
+      <Footer />
+      <ThemeToggle />
+    </main>
+  );
+}

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import heroData from "@/data/hero.json";
+import Navbar from "@/app/components/Navbar";
+import Footer from "@/app/components/Footer";
+import Experience from "@/app/components/Experience";
+import { ThemeToggle } from "@/app/components/ui/ThemeToggle";
+import { LazyMotionWrapper } from "@/app/components/ui/LazyMotionWrapper";
+
+const title = `Experience | ${heroData.name}`;
+const description =
+  "Work experience and shipped outcomes — grouped by company, with linked case studies and supporting projects.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical: "/experience" },
+  openGraph: {
+    title,
+    description,
+    url: "/experience",
+    type: "website",
+  },
+};
+
+export default function ExperienceIndexPage() {
+  return (
+    <main
+      id="content"
+      className="flex min-h-screen flex-col bg-background transition-colors duration-300"
+    >
+      <Navbar />
+      <div className="pt-24">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 pt-12 pb-4">
+          <span className="pill">Experience</span>
+          <h1 className="mt-5 text-4xl sm:text-5xl font-semibold tracking-tight text-text-primary">
+            Roles &amp; outcomes
+          </h1>
+          <p className="mt-4 text-text-secondary max-w-[72ch] leading-relaxed">
+            Company-by-company: scope, constraints, and shipped results.
+          </p>
+        </div>
+        <LazyMotionWrapper>
+          <Experience showTopBorder={false} showSeeMore={false} />
+        </LazyMotionWrapper>
+      </div>
+      <Footer />
+      <ThemeToggle />
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,17 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: dark;
+/* ============================================================
+   Palette CSS variable blocks — applied via data-palette attr
+   7 palettes: inkTeal, goldTeal, forestPink, purpleYellow,
+   blueGold, darkGreenGold, navyBlueGold
+   ============================================================ */
 
-  /* Typography */
-  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans",
-    sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
-
-  /* Brand palette (dark) — ink + copper + teal */
+/* === Palette: inkTeal (default) === */
+html[data-palette="inkTeal"] {
   --color-background: #0b0f14;
   --color-surface: #0f1823;
   --color-primary: #f59e0b;
@@ -21,17 +18,196 @@
   --color-text-primary: #e6edf3;
   --color-text-secondary: #b6c2d2;
   --color-text-tertiary: #7b8797;
+}
+html[data-palette="inkTeal"].light {
+  --color-background: #fbf7f2;
+  --color-surface: #ffffff;
+  --color-primary: #b45309;
+  --color-secondary: #0f766e;
+  --color-accent: #0f172a;
+  --color-text-primary: #0f172a;
+  --color-text-secondary: #334155;
+  --color-text-tertiary: #64748b;
+}
 
-  /* Layout + affordances */
+/* === Palette: goldTeal === */
+html[data-palette="goldTeal"] {
+  --color-background: #050e0d;
+  --color-surface: #0a1a18;
+  --color-primary: #FFBA00;
+  --color-secondary: #11AC9D;
+  --color-accent: #B2F7EF;
+  --color-text-primary: #e8faf8;
+  --color-text-secondary: #9dd9d2;
+  --color-text-tertiary: #5fa099;
+}
+html[data-palette="goldTeal"].light {
+  --color-background: #f0fffe;
+  --color-surface: #ffffff;
+  --color-primary: #b58600;
+  --color-secondary: #0b7a71;
+  --color-accent: #012e2b;
+  --color-text-primary: #012e2b;
+  --color-text-secondary: #134e48;
+  --color-text-tertiary: #3d8f87;
+}
+
+/* === Palette: forestPink === */
+html[data-palette="forestPink"] {
+  --color-background: #020f08;
+  --color-surface: #041a10;
+  --color-primary: #EC839E;
+  --color-secondary: #D3B238;
+  --color-accent: #F4B8C7;
+  --color-text-primary: #fce8ed;
+  --color-text-secondary: #c4a8b0;
+  --color-text-tertiary: #6a7060;
+}
+html[data-palette="forestPink"].light {
+  --color-background: #f0fff6;
+  --color-surface: #ffffff;
+  --color-primary: #0B6043;
+  --color-secondary: #D3B238;
+  --color-accent: #020f08;
+  --color-text-primary: #020f08;
+  --color-text-secondary: #0d3020;
+  --color-text-tertiary: #3d6050;
+}
+
+/* === Palette: purpleYellow === */
+html[data-palette="purpleYellow"] {
+  --color-background: #0d0015;
+  --color-surface: #1a0030;
+  --color-primary: #F9D402;
+  --color-secondary: #9C59BD;
+  --color-accent: #e8d0ff;
+  --color-text-primary: #f0e8ff;
+  --color-text-secondary: #c0a0d8;
+  --color-text-tertiary: #7a5099;
+}
+html[data-palette="purpleYellow"].light {
+  --color-background: #faf0ff;
+  --color-surface: #ffffff;
+  --color-primary: #660099;
+  --color-secondary: #C79C0E;
+  --color-accent: #0d0015;
+  --color-text-primary: #0d0015;
+  --color-text-secondary: #2a0044;
+  --color-text-tertiary: #6a3088;
+}
+
+/* === Palette: blueGold — commented out, available for later ===
+html[data-palette="blueGold"] {
+  --color-background: #000814;
+  --color-surface: #001D3D;
+  --color-primary: #CCA000;
+  --color-secondary: #F0CB46;
+  --color-accent: #e0efff;
+  --color-text-primary: #e0efff;
+  --color-text-secondary: #a0bce0;
+  --color-text-tertiary: #4a78b8;
+}
+html[data-palette="blueGold"].light {
+  --color-background: #f0f4ff;
+  --color-surface: #ffffff;
+  --color-primary: #CCA000;
+  --color-secondary: #003566;
+  --color-accent: #000814;
+  --color-text-primary: #000814;
+  --color-text-secondary: #00224a;
+  --color-text-tertiary: #2a5a90;
+}
+=== */
+
+/* === Palette: darkGreenGold === */
+html[data-palette="darkGreenGold"] {
+  --color-background: #020d0a;
+  --color-surface: #06362D;
+  --color-primary: #FFD500;
+  --color-secondary: #D1A505;
+  --color-accent: #DEE2B1;
+  --color-text-primary: #eef5e0;
+  --color-text-secondary: #b0c8a0;
+  --color-text-tertiary: #5a8870;
+}
+html[data-palette="darkGreenGold"].light {
+  --color-background: #f0fff6;
+  --color-surface: #ffffff;
+  --color-primary: #D1A505;
+  --color-secondary: #06362D;
+  --color-accent: #020d0a;
+  --color-text-primary: #020d0a;
+  --color-text-secondary: #0a2820;
+  --color-text-tertiary: #2a6050;
+}
+
+/* === Palette: navyBlueGold === */
+html[data-palette="navyBlueGold"] {
+  --color-background: #00001a;
+  --color-surface: #000040;
+  --color-primary: #FFD60A;
+  --color-secondary: #FFBF1C;
+  --color-accent: #dce8ff;
+  --color-text-primary: #dce8ff;
+  --color-text-secondary: #9ab0e0;
+  --color-text-tertiary: #4868b8;
+}
+html[data-palette="navyBlueGold"].light {
+  --color-background: #f0f0ff;
+  --color-surface: #ffffff;
+  --color-primary: #D1A309;
+  --color-secondary: #000080;
+  --color-accent: #00001a;
+  --color-text-primary: #00001a;
+  --color-text-secondary: #00006a;
+  --color-text-tertiary: #2828a0;
+}
+
+/* ============================================================
+   End palette blocks
+   ============================================================ */
+
+:root {
+  /* Typography — always set, not palette-dependent */
+  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans",
+    sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+
+  /* Layout + affordances — not palette-dependent */
   --radius: 16px;
   --radius-sm: 12px;
+}
+
+/* Fallback dark colors only when no data-palette is set */
+:root:not([data-palette]) {
+  color-scheme: dark;
+  --color-background: #0b0f14;
+  --color-surface: #0f1823;
+  --color-primary: #f59e0b;
+  --color-secondary: #14b8a6;
+  --color-accent: #e2e8f0;
+  --color-text-primary: #e6edf3;
+  --color-text-secondary: #b6c2d2;
+  --color-text-tertiary: #7b8797;
   --border: color-mix(in oklab, var(--color-text-tertiary) 35%, transparent);
   --shadow-soft: 0 24px 70px -40px rgba(0, 0, 0, 0.7);
   --shadow-lift: 0 18px 45px -32px rgba(0, 0, 0, 0.8);
   --ring: color-mix(in oklab, var(--color-secondary) 65%, transparent);
 }
 
-:root.light {
+/* Dark mode layout tokens — always apply regardless of palette */
+html.dark {
+  color-scheme: dark;
+  --border: color-mix(in oklab, var(--color-text-tertiary) 35%, transparent);
+  --shadow-soft: 0 24px 70px -40px rgba(0, 0, 0, 0.7);
+  --shadow-lift: 0 18px 45px -32px rgba(0, 0, 0, 0.8);
+  --ring: color-mix(in oklab, var(--color-secondary) 65%, transparent);
+}
+
+/* Fallback light colors only when no data-palette is set */
+:root:not([data-palette]).light {
   color-scheme: light;
 
   /* Brand palette (light) — paper + copper + teal */
@@ -43,7 +219,11 @@
   --color-text-primary: #0f172a;
   --color-text-secondary: #334155;
   --color-text-tertiary: #64748b;
+}
 
+/* Light mode layout tokens — always apply regardless of palette */
+html.light {
+  color-scheme: light;
   --border: color-mix(in oklab, var(--color-text-tertiary) 28%, transparent);
   --shadow-soft: 0 24px 70px -48px rgba(2, 6, 23, 0.28);
   --shadow-lift: 0 18px 45px -34px rgba(2, 6, 23, 0.28);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,13 +11,21 @@ const description = [heroData.shortDescription, heroData.shortDescriptionLine2]
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
-  title: `${heroData.name} | Portfolio`,
+  title: {
+    default: `${heroData.name} | Portfolio`,
+    template: `%s | Krishnatejaswi Shenthar`,
+  },
   description,
   openGraph: {
     title: `${heroData.name} | Portfolio`,
     description,
     url: "/",
     type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${heroData.name} | Portfolio`,
+    description,
   },
 };
 
@@ -27,8 +35,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('theme');var p=localStorage.getItem('palette')||'forestPink';document.documentElement.classList.add(t==='light'?'light':'dark');document.documentElement.setAttribute('data-palette',p);}catch(e){}})();`,
+          }}
+        />
         <link
           rel="alternate"
           type="text/plain"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,28 +1,17 @@
 import Navbar from "./components/Navbar";
-import dynamic from "next/dynamic";
-import { SmoothScroll } from "./components/ui/SmoothScroll";
-import { LazyMotionWrapper } from "./components/ui/LazyMotionWrapper";
+import Hero from "./components/Hero";
+import Footer from "./components/Footer";
 import Script from "next/script";
+import { LazyMotionWrapper } from "./components/ui/LazyMotionWrapper";
 import { buildJsonLd, getProfileData, getSiteUrl } from "@/lib/profile";
-
-const HeroSection = dynamic(() => import("./components/Hero"), {
-  ssr: true,
-  loading: () => <div className="min-h-screen bg-background" />,
-});
-const ExperienceSection = dynamic(() => import("./components/Experience"), {
-  ssr: true,
-});
-const AboutSection = dynamic(() => import("./components/About"), { ssr: true });
-const ProjectsSection = dynamic(() => import("./components/Projects"), {
-  ssr: true,
-});
-const EmailSection = dynamic(() => import("./components/Contact"), {
-  ssr: true,
-});
-const Footer = dynamic(() => import("./components/Footer"), { ssr: true });
+import { ThemeToggle } from "./components/ui/ThemeToggle";
+import { ThemePreviewPanel } from "./components/ui/ThemePreviewPanel";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { ThemeToggle } from "./components/ui/ThemeToggle";
+import FeaturedExperience from "./components/home/FeaturedExperience";
+import FeaturedProjects from "./components/home/FeaturedProjects";
+import ValueSection from "./components/home/ValueSection";
+import CtaSection from "./components/home/CtaSection";
 
 export default function Home() {
   const siteUrl = getSiteUrl();
@@ -37,20 +26,16 @@ export default function Home() {
         strategy="beforeInteractive"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <main
-        id="content"
-        className="flex min-h-screen flex-col bg-background transition-colors duration-300"
-      >
-        <SmoothScroll />
+      <main id="content" className="flex min-h-screen flex-col bg-background transition-colors duration-300">
         <Navbar />
-        <HeroSection />
-        <ExperienceSection condensed />
-        <ProjectsSection />
-        <AboutSection />
-        <EmailSection />
-
+        <Hero />
+        <FeaturedExperience />
+        <FeaturedProjects />
+        <ValueSection />
+        <CtaSection />
         <Footer />
         <ThemeToggle />
+        <ThemePreviewPanel />
         <Analytics />
         <SpeedInsights />
       </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import Script from "next/script";
 import { LazyMotionWrapper } from "./components/ui/LazyMotionWrapper";
 import { buildJsonLd, getProfileData, getSiteUrl } from "@/lib/profile";
 import { ThemeToggle } from "./components/ui/ThemeToggle";
-import { ThemePreviewPanel } from "./components/ui/ThemePreviewPanel";
+// import { ThemePreviewPanel } from "./components/ui/ThemePreviewPanel";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import FeaturedExperience from "./components/home/FeaturedExperience";
@@ -35,7 +35,7 @@ export default function Home() {
         <CtaSection />
         <Footer />
         <ThemeToggle />
-        <ThemePreviewPanel />
+        {/* <ThemePreviewPanel /> */}
         <Analytics />
         <SpeedInsights />
       </main>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,25 +1,16 @@
 import type { Metadata } from "next";
-import heroData from "@/data/hero.json";
 import Navbar from "@/app/components/Navbar";
 import Footer from "@/app/components/Footer";
 import Projects from "@/app/components/Projects";
 import { ThemeToggle } from "@/app/components/ui/ThemeToggle";
+import { buildPageMetadata } from "@/lib/metadata";
 
-const title = `Work & Projects | ${heroData.name}`;
-const description =
-  "Projects, publications, and end-to-end work (discovery → development → deployment).";
-
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: { canonical: "/projects" },
-  openGraph: {
-    title,
-    description,
-    url: "/projects",
-    type: "website",
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: "Work & Projects",
+  description:
+    "Projects, publications, and end-to-end work — discovery to deployment.",
+  path: "/projects",
+});
 
 export default function ProjectsPage() {
   return (
@@ -28,11 +19,19 @@ export default function ProjectsPage() {
       className="flex min-h-screen flex-col bg-background transition-colors duration-300"
     >
       <Navbar />
-      <h1 className="sr-only">Work and projects by {heroData.name}</h1>
       <div className="pt-24">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 pt-12 pb-4">
+          <span className="pill">Work</span>
+          <h1 className="mt-5 text-4xl sm:text-5xl font-semibold tracking-tight text-text-primary">
+            Selected projects
+          </h1>
+          <p className="mt-4 text-text-secondary max-w-[72ch] leading-relaxed">
+            Each project is framed as a short case study: the problem, the
+            approach, and the measurable impact.
+          </p>
+        </div>
         <Projects showTopBorder={false} />
       </div>
-
       <Footer />
       <ThemeToggle />
     </main>

--- a/src/app/publications/page.tsx
+++ b/src/app/publications/page.tsx
@@ -1,31 +1,21 @@
-import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
-import heroData from "@/data/hero.json";
 import projectsData from "@/data/projects.json";
 import Navbar from "@/app/components/Navbar";
 import Footer from "@/app/components/Footer";
 import { ThemeToggle } from "@/app/components/ui/ThemeToggle";
+import { buildPageMetadata } from "@/lib/metadata";
 
 const publications = projectsData.projects.filter((project) =>
   project.tag.includes("Publication"),
 );
 
-const title = `Publications | ${heroData.name}`;
-const description =
-  "Research publications and technical work by Krishnatejaswi Shenthar.";
-
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: { canonical: "/publications" },
-  openGraph: {
-    title,
-    description,
-    url: "/publications",
-    type: "website",
-  },
-};
+export const metadata = buildPageMetadata({
+  title: "Publications",
+  description:
+    "Research publications and technical work by Krishnatejaswi Shenthar.",
+  path: "/publications",
+});
 
 export default function PublicationsPage() {
   return (
@@ -34,55 +24,68 @@ export default function PublicationsPage() {
       className="flex min-h-screen flex-col bg-background transition-colors duration-300"
     >
       <Navbar />
-      <div className="container mt-24 mx-auto px-4 sm:px-8 md:px-12 py-12">
-        <h1 className="text-4xl sm:text-5xl font-semibold tracking-tight text-text-primary">
-          Writing & publications
-        </h1>
-        <p className="mt-4 text-text-secondary max-w-[72ch] leading-relaxed">
-          Selected publications and research work. For engineering work and
-          projects, see{" "}
-          <Link href="/projects" className="link-underline text-text-primary">
-            selected work
-          </Link>
-          .
-        </p>
+      <div className="pt-24">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 pt-12 pb-4">
+          <span className="pill">Research</span>
+          <h1 className="mt-5 text-4xl sm:text-5xl font-semibold tracking-tight text-text-primary">
+            Writing &amp; publications
+          </h1>
+          <p className="mt-4 text-text-secondary max-w-[72ch] leading-relaxed">
+            Selected publications and research work. For engineering work and
+            projects, see{" "}
+            <Link href="/projects" className="link-underline text-text-primary">
+              selected work
+            </Link>
+            .
+          </p>
+        </div>
 
-        <ul className="mt-12 grid grid-cols-1 md:grid-cols-2 gap-6">
-          {publications.map((pub) => (
-            <li
-              key={pub.id}
-              className="surface-card overflow-hidden transition-transform duration-200 hover:-translate-y-0.5"
-            >
-              <a
-                href={pub.links?.paper || pub.link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex flex-col h-full"
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 pb-12">
+          <ul className="mt-12 grid grid-cols-1 md:grid-cols-2 gap-6">
+            {publications.map((pub) => (
+              <li
+                key={pub.id}
+                className="surface-card overflow-hidden transition-transform duration-200 hover:-translate-y-0.5"
               >
-                <div className="relative h-44 border-b border-text-tertiary/20 overflow-hidden bg-[color-mix(in_oklab,var(--color-surface)_88%,transparent)]">
-                  <Image
-                    src={pub.image}
-                    alt={`Cover image for ${pub.name}`}
-                    fill
-                    className="object-cover"
-                    sizes="(max-width: 768px) 100vw, 50vw"
-                  />
-                </div>
-                <div className="p-6 flex flex-col flex-grow">
-                  <h2 className="text-xl font-semibold tracking-tight text-text-primary">
-                    {pub.name}
-                  </h2>
-                  <p className="mt-3 text-text-secondary text-sm leading-relaxed line-clamp-5 flex-grow">
-                    {pub.description}
-                  </p>
-                  <div className="mt-6 pt-4 border-t border-text-tertiary/10 text-text-secondary font-mono text-xs uppercase tracking-widest">
-                    Read paper
+                <a
+                  href={pub.links?.paper || pub.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex flex-col h-full"
+                >
+                  <div className="relative h-44 border-b border-text-tertiary/20 overflow-hidden bg-[color-mix(in_oklab,var(--color-surface)_88%,transparent)]">
+                    <Image
+                      src={pub.image}
+                      alt={`Cover image for ${pub.name}`}
+                      fill
+                      className="object-cover"
+                      sizes="(max-width: 768px) 100vw, 50vw"
+                    />
                   </div>
-                </div>
-              </a>
-            </li>
-          ))}
-        </ul>
+                  <div className="p-6 flex flex-col flex-grow">
+                    <h2 className="text-xl font-semibold tracking-tight text-text-primary">
+                      {pub.name}
+                    </h2>
+                    <p className="mt-3 text-text-secondary text-sm leading-relaxed line-clamp-5 flex-grow">
+                      {pub.description}
+                    </p>
+                    <div className="mt-6 pt-4 border-t border-text-tertiary/10 text-text-secondary font-mono text-xs uppercase tracking-widest">
+                      Read paper
+                    </div>
+                  </div>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-12 border-t border-text-tertiary/10">
+          <div className="flex flex-wrap gap-3">
+            <Link href="/projects" className="btn btn-primary">
+              View projects
+            </Link>
+          </div>
+        </div>
       </div>
       <Footer />
       <ThemeToggle />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,50 +1,31 @@
 import type { MetadataRoute } from "next";
 import { getSiteUrl } from "@/lib/profile";
 import experienceData from "@/data/experience.json";
+import workData from "@/data/work.json";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const siteUrl = getSiteUrl();
   const lastModified = new Date();
 
-  const companyUrls =
-    experienceData.experience?.map((entry) => ({
-      url: `${siteUrl}/work/${entry.slug}`,
-      lastModified,
-    })) || [];
+  const experienceUrls = experienceData.experience?.map((entry) => ({
+    url: `${siteUrl}/experience/${entry.slug}`,
+    lastModified,
+  })) || [];
+
+  const caseStudyUrls = (workData.work || []).map((item) => ({
+    url: `${siteUrl}/case-studies/${item.slug}`,
+    lastModified,
+  }));
 
   return [
-    {
-      url: `${siteUrl}/`,
-      lastModified,
-    },
-    {
-      url: `${siteUrl}/about`,
-      lastModified,
-    },
-    {
-      url: `${siteUrl}/projects`,
-      lastModified,
-    },
-    {
-      url: `${siteUrl}/publications`,
-      lastModified,
-    },
-    {
-      url: `${siteUrl}/contact`,
-      lastModified,
-    },
-    {
-      url: `${siteUrl}/work`,
-      lastModified,
-    },
-    ...companyUrls,
-    {
-      url: `${siteUrl}/work/complianceos`,
-      lastModified,
-    },
-    {
-      url: `${siteUrl}/llms.txt`,
-      lastModified,
-    },
+    { url: `${siteUrl}/`, lastModified },
+    { url: `${siteUrl}/about`, lastModified },
+    { url: `${siteUrl}/projects`, lastModified },
+    { url: `${siteUrl}/publications`, lastModified },
+    { url: `${siteUrl}/contact`, lastModified },
+    { url: `${siteUrl}/experience`, lastModified },
+    ...experienceUrls,
+    ...caseStudyUrls,
+    { url: `${siteUrl}/llms.txt`, lastModified },
   ];
 }

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,25 +1,16 @@
-import type { Metadata } from "next";
 import heroData from "@/data/hero.json";
 import Navbar from "@/app/components/Navbar";
 import Footer from "@/app/components/Footer";
 import Experience from "@/app/components/Experience";
 import { ThemeToggle } from "@/app/components/ui/ThemeToggle";
+import { buildPageMetadata } from "@/lib/metadata";
 
-const title = `Experience | ${heroData.name}`;
-const description =
-  "Work experience and shipped outcomes — grouped by company, with linked case studies and supporting projects.";
-
-export const metadata: Metadata = {
-  title,
-  description,
-  alternates: { canonical: "/work" },
-  openGraph: {
-    title,
-    description,
-    url: "/work",
-    type: "website",
-  },
-};
+export const metadata = buildPageMetadata({
+  title: "Experience",
+  description:
+    "Work experience and shipped outcomes — grouped by company, with linked case studies and supporting projects.",
+  path: "/work",
+});
 
 export default function WorkIndexPage() {
   return (

--- a/src/data/contact.json
+++ b/src/data/contact.json
@@ -8,12 +8,20 @@
     "display": "WA.ME/KTS",
     "link": "https://wa.me/917760951918"
   },
+  "bookingUrl": "https://calendar.app.google/zjsY3uvWa4avw1wq6",
+  "resumeUrl": "https://drive.google.com/file/d/1uy1w2prce_k-YD5bZrxUytEDXIXil6-2/view?usp=sharing",
+  "availability": "Available for full-time roles and select freelance projects.",
   "description": "I'm always open to discussing new projects, AI innovations, or technical opportunities. Feel free to reach out via email or any of my social nodes.",
   "socialMedia": [
     {
       "platform": "github",
       "url": "https://www.github.com/KTS-o7/",
       "icon": "faGithub"
+    },
+    {
+      "platform": "twitter",
+      "url": "https://x.com/kts_o7",
+      "icon": "faXTwitter"
     },
     {
       "platform": "linkedin",

--- a/src/data/experience.json
+++ b/src/data/experience.json
@@ -37,7 +37,7 @@
       "caseStudies": [
         {
           "title": "ComplianceOS (deep dive)",
-          "href": "/work/complianceos"
+          "href": "/case-studies/complianceos"
         }
       ],
       "selectedProjectIds": []

--- a/src/data/hero.json
+++ b/src/data/hero.json
@@ -26,29 +26,25 @@
       "value": "End‑to‑end: design → deploy"
     }
   ],
+  "bookingUrl": "https://calendar.app.google/zjsY3uvWa4avw1wq6",
+  "resumeUrl": "https://drive.google.com/file/d/1uy1w2prce_k-YD5bZrxUytEDXIXil6-2/view?usp=sharing",
   "buttons": [
     {
-      "text": "Projects",
-      "link": "#projects",
+      "text": "Book a call",
+      "link": "https://calendar.app.google/zjsY3uvWa4avw1wq6",
       "type": "primary",
+      "external": true
+    },
+    {
+      "text": "View selected work",
+      "link": "/projects",
+      "type": "secondary",
       "external": false
     },
     {
       "text": "Resume",
-      "link": "https://drive.google.com/file/d/1uy1w2prce_k-YD5bZrxUytEDXIXil6-2/view",
+      "link": "https://drive.google.com/file/d/1uy1w2prce_k-YD5bZrxUytEDXIXil6-2/view?usp=sharing",
       "type": "secondary",
-      "external": true
-    },
-    {
-      "text": "Experience",
-      "link": "#experience",
-      "type": "secondary",
-      "external": false
-    },
-    {
-      "text": "Writing",
-      "link": "https://kts-o7.github.io/blog/",
-      "type": "tertiary",
       "external": true
     }
   ]

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+
+const SITE_NAME = "Krishnatejaswi Shenthar";
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://krishnatejaswi.com";
+
+export function buildPageMetadata({
+  title,
+  description,
+  path,
+  type = "website",
+}: {
+  title: string;
+  description: string;
+  path: string;
+  type?: "website" | "profile" | "article";
+}): Metadata {
+  const url = path.startsWith("http") ? path : `${BASE_URL}${path}`;
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: path,
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      type,
+      siteName: SITE_NAME,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -31,6 +31,7 @@ type ProfileData = {
     linkedin?: string;
     blog?: string;
     resume?: string;
+    booking?: string;
     employer?: string;
   };
   skills: string[];
@@ -85,7 +86,8 @@ export const getProfileData = (baseUrl: string): ProfileData => {
   const github = getLinkByPlatform("github");
   const linkedin = getLinkByPlatform("linkedin");
   const blog = findButtonLink(/blog/i);
-  const resume = findButtonLink(/cv|resume/i);
+  const booking = (heroData as any).bookingUrl;
+  const resume = (heroData as any).resumeUrl || findButtonLink(/cv|resume/i);
   const employer = "https://www.onfinance.ai/company";
 
   const skills = dedupeList([
@@ -122,6 +124,7 @@ export const getProfileData = (baseUrl: string): ProfileData => {
       linkedin,
       blog,
       resume,
+      booking,
       employer,
     },
     skills,
@@ -174,7 +177,7 @@ export const buildLlmProfileText = (profile: ProfileData) => {
       .map((item) => {
         const company = item.company?.name ? ` (${item.company.name})` : "";
         const shortDescription = item.subtitle || item.summary?.[0] || "";
-        const url = `${profile.links.website}/work/${item.slug}`;
+        const url = `${profile.links.website}/case-studies/${item.slug}`;
         return `- ${item.title}${company}: ${shortDescription} — ${url}`;
       })
       .join("\n");
@@ -187,6 +190,32 @@ export const buildLlmProfileText = (profile: ProfileData) => {
   parts.push(`## Location\n${profile.location}`);
   parts.push(
     `## Work preferences\n- Open to: Bangalore (India), remote, relocation (good opportunities/comp)`,
+  );
+  parts.push(
+    `## Availability\nAvailable for full-time roles and select freelance projects. Based in Bangalore, India. Open to remote and relocation for strong opportunities.`,
+  );
+  parts.push(
+    `## How to engage\n` +
+      [
+        profile.links.booking && `- Book a call: ${profile.links.booking}`,
+        profile.links.resume && `- Resume/CV: ${profile.links.resume}`,
+        profile.contact.email && `- Email: ${profile.contact.email}`,
+      ]
+        .filter(Boolean)
+        .join("\n"),
+  );
+  parts.push(
+    `## Canonical pages\n` +
+      [
+        `- Home: ${profile.links.website}/`,
+        `- Experience: ${profile.links.website}/experience`,
+        `- Case studies: ${profile.links.website}/case-studies/complianceos`,
+        `- Projects: ${profile.links.website}/projects`,
+        `- About: ${profile.links.website}/about`,
+        `- Contact: ${profile.links.website}/contact`,
+        `- Publications: ${profile.links.website}/publications`,
+        `- Machine-readable profile: ${profile.links.website}/llms.txt`,
+      ].join("\n"),
   );
   parts.push(
     `## Links\n` +
@@ -284,7 +313,7 @@ export const buildJsonLd = (profile: ProfileData, baseUrl: string) => {
     "@id": `${baseUrl}#featured-work-${index + 1}`,
     name: item.title,
     description: item.summary?.join(" ") || "",
-    url: `${baseUrl}/work/${item.slug}`,
+    url: `${baseUrl}/case-studies/${item.slug}`,
     creator: { "@id": personId },
     publisher: {
       "@type": "Organization",

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,0 +1,190 @@
+export type ColorTokens = {
+  background: string;
+  surface: string;
+  primary: string;
+  secondary: string;
+  accent: string;
+  textPrimary: string;
+  textSecondary: string;
+  textTertiary: string;
+};
+
+export type PaletteTokens = {
+  dark: ColorTokens;
+  light: ColorTokens;
+};
+
+export const themePalettes: Record<string, PaletteTokens> = {
+  // 0. Default — ink + teal + amber
+  inkTeal: {
+    dark: {
+      background: "#0b0f14",
+      surface: "#0f1823",
+      primary: "#f59e0b",
+      secondary: "#14b8a6",
+      accent: "#e2e8f0",
+      textPrimary: "#e6edf3",
+      textSecondary: "#b6c2d2",
+      textTertiary: "#7b8797",
+    },
+    light: {
+      background: "#fbf7f2",
+      surface: "#ffffff",
+      primary: "#b45309",
+      secondary: "#0f766e",
+      accent: "#0f172a",
+      textPrimary: "#0f172a",
+      textSecondary: "#334155",
+      textTertiary: "#64748b",
+    },
+  },
+  // 1. Gold & Teal
+  goldTeal: {
+    dark: {
+      background: "#050e0d",
+      surface: "#0a1a18",
+      primary: "#FFBA00",
+      secondary: "#11AC9D",
+      accent: "#B2F7EF",
+      textPrimary: "#e8faf8",
+      textSecondary: "#9dd9d2",
+      textTertiary: "#5fa099",
+    },
+    light: {
+      background: "#f0fffe",
+      surface: "#ffffff",
+      primary: "#b58600",
+      secondary: "#0b7a71",
+      accent: "#012e2b",
+      textPrimary: "#012e2b",
+      textSecondary: "#134e48",
+      textTertiary: "#3d8f87",
+    },
+  },
+  // 2. Forest & Pink
+  forestPink: {
+    dark: {
+      background: "#020f08",
+      surface: "#041a10",
+      primary: "#EC839E",
+      secondary: "#D3B238",
+      accent: "#F4B8C7",
+      textPrimary: "#fce8ed",
+      textSecondary: "#c4a8b0",
+      textTertiary: "#6a7060",
+    },
+    light: {
+      background: "#f0fff6",
+      surface: "#ffffff",
+      primary: "#0B6043",
+      secondary: "#D3B238",
+      accent: "#020f08",
+      textPrimary: "#020f08",
+      textSecondary: "#0d3020",
+      textTertiary: "#3d6050",
+    },
+  },
+  // 3. Purple & Yellow
+  purpleYellow: {
+    dark: {
+      background: "#0d0015",
+      surface: "#1a0030",
+      primary: "#F9D402",
+      secondary: "#9C59BD",
+      accent: "#e8d0ff",
+      textPrimary: "#f0e8ff",
+      textSecondary: "#c0a0d8",
+      textTertiary: "#7a5099",
+    },
+    light: {
+      background: "#faf0ff",
+      surface: "#ffffff",
+      primary: "#660099",
+      secondary: "#C79C0E",
+      accent: "#0d0015",
+      textPrimary: "#0d0015",
+      textSecondary: "#2a0044",
+      textTertiary: "#6a3088",
+    },
+  },
+  // 4. Blue & Gold — commented out, available for later
+  // blueGold: {
+  //   dark: {
+  //     background: "#000814",
+  //     surface: "#001D3D",
+  //     primary: "#CCA000",
+  //     secondary: "#F0CB46",
+  //     accent: "#e0efff",
+  //     textPrimary: "#e0efff",
+  //     textSecondary: "#a0bce0",
+  //     textTertiary: "#4a78b8",
+  //   },
+  //   light: {
+  //     background: "#f0f4ff",
+  //     surface: "#ffffff",
+  //     primary: "#CCA000",
+  //     secondary: "#003566",
+  //     accent: "#000814",
+  //     textPrimary: "#000814",
+  //     textSecondary: "#00224a",
+  //     textTertiary: "#2a5a90",
+  //   },
+  // },
+  // 5. Dark Green & Gold
+  darkGreenGold: {
+    dark: {
+      background: "#020d0a",
+      surface: "#06362D",
+      primary: "#FFD500",
+      secondary: "#D1A505",
+      accent: "#DEE2B1",
+      textPrimary: "#eef5e0",
+      textSecondary: "#b0c8a0",
+      textTertiary: "#5a8870",
+    },
+    light: {
+      background: "#f0fff6",
+      surface: "#ffffff",
+      primary: "#D1A505",
+      secondary: "#06362D",
+      accent: "#020d0a",
+      textPrimary: "#020d0a",
+      textSecondary: "#0a2820",
+      textTertiary: "#2a6050",
+    },
+  },
+  // 6. Navy Blue & Gold
+  navyBlueGold: {
+    dark: {
+      background: "#00001a",
+      surface: "#000040",
+      primary: "#FFD60A",
+      secondary: "#FFBF1C",
+      accent: "#dce8ff",
+      textPrimary: "#dce8ff",
+      textSecondary: "#9ab0e0",
+      textTertiary: "#4868b8",
+    },
+    light: {
+      background: "#f0f0ff",
+      surface: "#ffffff",
+      primary: "#D1A309",
+      secondary: "#000080",
+      accent: "#00001a",
+      textPrimary: "#00001a",
+      textSecondary: "#00006a",
+      textTertiary: "#2828a0",
+    },
+  },
+};
+
+// Human-readable labels for the preview panel
+export const paletteLabels: Record<string, string> = {
+  inkTeal: "Ink & Teal (default)",
+  goldTeal: "Gold & Teal",
+  forestPink: "Forest & Pink",
+  purpleYellow: "Purple & Yellow",
+  // blueGold: "Blue & Gold",
+  darkGreenGold: "Dark Green & Gold",
+  navyBlueGold: "Navy Blue & Gold",
+};


### PR DESCRIPTION
## Summary

- Replaces long SPA homepage with short multi-section landing page (Hero, Featured Experience, Featured Projects, Value, CTA)
- Adds canonical `/experience` and `/case-studies` routes with permanent redirects from `/work/*`
- Rebuilds Navbar with clean route-based links and always-visible Resume + Book a call CTAs
- Adds 7-palette theme system (Forest & Pink default, Blue & Gold commented out for later) with live dark/light support per palette
- Fixes ThemeContext hydration mismatch using `useSyncExternalStore`
- Centralizes SEO with `buildPageMetadata` helper, stronger sitemap, richer `llms.txt`
- Refreshes all inner pages (About, Contact, Projects, Publications, Experience) with proper headings and CTAs
- Adds Twitter/X to Contact and Footer social links
- Palette preview panel is hidden (commented out) for prod

## Notes
- `ThemePreviewPanel` component is kept in the codebase but commented out in `page.tsx` — uncomment locally to preview palettes
- `blueGold` palette is commented out in `themes.ts`, `globals.css`, and `paletteLabels` — easy to restore
- No breaking changes to existing `/work/*` routes (they redirect permanently)