### PR TITLE
Fix canonical domain → portfolio.shenthar.me

### DIFF
--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 const SITE_NAME = "Krishnatejaswi Shenthar";
-const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://krishnatejaswi.com";
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://portfolio.shenthar.me";
 
 export const SITE_KEYWORDS = [
   "Krishnatejaswi Shenthar",

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -77,7 +77,7 @@ export const getSiteUrl = (origin?: string) => {
     process.env.NEXT_PUBLIC_SITE_URL ||
     (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);
 
-  const base = envUrl || origin || "http://localhost:3000";
+  const base = envUrl || origin || "https://portfolio.shenthar.me";
   return base.replace(/\/$/, "");
 };
 


### PR DESCRIPTION
`BASE_URL` fallback in `src/lib/metadata.ts` pointed at `krishnatejaswi.com`, which isn't owned. Defaults now use `https://portfolio.shenthar.me`:

- `src/lib/metadata.ts` — `BASE_URL` fallback
- `src/lib/profile.ts` — `getSiteUrl()` fallback (was `localhost:3000`)

Fixes canonical links, sitemap.xml, robots, OG/Twitter URLs, and JSON-LD `url`/`@id` fields when `NEXT_PUBLIC_SITE_URL` is unset. Build passes.