### PR TITLE
Fix Vercel build warnings + canonical URL priority

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=22.x"
+    "node": "22.x"
   },
   "scripts": {
     "dev": "next dev",

--- a/src/app/llm.txt/route.ts
+++ b/src/app/llm.txt/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
+import { getSiteUrl } from "@/lib/profile";
 
-export const runtime = "edge";
+export const dynamic = "force-static";
 
-export async function GET(request: NextRequest) {
-  const redirectUrl = new URL("/llms.txt", request.nextUrl);
-  return NextResponse.redirect(redirectUrl, 301);
+export function GET() {
+  return NextResponse.redirect(`${getSiteUrl()}/llms.txt`, 301);
 }

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { buildLlmProfileText, getProfileData, getSiteUrl } from "@/lib/profile";
 
-export const runtime = "edge";
+export const dynamic = "force-static";
+export const revalidate = 3600;
 
-export async function GET(request: NextRequest) {
-  const baseUrl = getSiteUrl(request.nextUrl.origin);
+export function GET() {
+  const baseUrl = getSiteUrl();
   const profile = getProfileData(baseUrl);
   const body = buildLlmProfileText(profile);
 

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -73,11 +73,16 @@ const dedupeList = (items: string[]) => {
 };
 
 export const getSiteUrl = (origin?: string) => {
-  const envUrl =
+  // Canonical domain always wins on Vercel: VERCEL_URL is the
+  // per-deployment host, never the custom domain, so it stays last.
+  const base =
     process.env.NEXT_PUBLIC_SITE_URL ||
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);
-
-  const base = envUrl || origin || "https://portfolio.shenthar.me";
+    (process.env.VERCEL_ENV === "production"
+      ? "https://portfolio.shenthar.me"
+      : undefined) ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined) ||
+    origin ||
+    "https://portfolio.shenthar.me";
   return base.replace(/\/$/, "");
 };
 


### PR DESCRIPTION
## Fixes both warnings from the build log
1. `engines.node: >=22.x` → `22.x` — stops the "will automatically upgrade" warning
2. `edge runtime disables static generation` — `llms.txt`/`llm.txt` no longer use edge; both are now `force-static` (llms.txt revalidates hourly, llm.txt is a static 301)

## Bonus fix (related, SEO)
`getSiteUrl()` previously preferred `VERCEL_URL` — the per-deployment `*.vercel.app` host — over the real domain on Vercel. Canonical links, sitemap, robots, OG URLs and llms.txt would have pointed at the wrong host in production. Now: `NEXT_PUBLIC_SITE_URL` → canonical domain (prod) → `VERCEL_URL` (previews/local fallbacks).

Lint clean, build passes.