### PR TITLE
Upgrade Node engine to 24.x (latest LTS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "22.x"
+    "node": "24.x"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Pins `engines.node` to `24.x` — the current active LTS, supported by Vercel. Also resolves the `>=22.x` auto-upgrade warning from the build log.

Note: PR #19 pinned `22.x` for the same warning — merge that one first and this becomes a clean one-line upgrade (or close #19's engines hunk in favor of this). Build passes locally on Node 26.