### PR TITLE
Add Copy RSS link button to blog

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import Navbar from "@/app/components/Navbar";
 import Footer from "@/app/components/Footer";
 import BlogIndex, {
   type BlogPostSummary,
 } from "@/app/components/blog/BlogIndex";
+import CopyRssButton from "@/app/components/blog/CopyRssButton";
 import {
   formatPostDate,
   getPostsBySection,
@@ -57,9 +59,20 @@ export default function BlogIndexPage() {
       <Navbar />
       <div className="pt-24">
         <div className="max-w-[1100px] mx-auto px-4 sm:px-6 pt-12 pb-20">
-          <span className="font-mono text-xs uppercase tracking-widest text-text-tertiary">
-            Blog
-          </span>
+          <div className="flex items-baseline justify-between">
+            <span className="font-mono text-xs uppercase tracking-widest text-text-tertiary">
+              Blog
+            </span>
+            <span className="flex items-baseline gap-5">
+              <Link
+                href="/blog/rss.xml"
+                className="font-mono text-xs uppercase tracking-widest text-text-tertiary hover:text-primary transition-colors link-underline"
+              >
+                RSS →
+              </Link>
+              <CopyRssButton />
+            </span>
+          </div>
           <h1 className="mt-5 text-4xl sm:text-5xl font-semibold tracking-tight text-text-primary">
             Writing
           </h1>

--- a/src/app/components/blog/CopyRssButton.tsx
+++ b/src/app/components/blog/CopyRssButton.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Copies the blog RSS feed URL to the clipboard.
+ * Rendered in the /blog header next to the feed link.
+ */
+export default function CopyRssButton() {
+  const [label, setLabel] = useState("Copy RSS link");
+
+  const onClick = async () => {
+    const url = `${window.location.origin}/blog/rss.xml`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setLabel("Copied");
+    } catch {
+      setLabel("Failed");
+    }
+    setTimeout(() => setLabel("Copy RSS link"), 1500);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="font-mono text-xs uppercase tracking-widest text-text-tertiary hover:text-primary transition-colors link-underline"
+    >
+      {label}
+    </button>
+  );
+}


### PR DESCRIPTION
Adds an **RSS →** link and a **Copy RSS link** button to the `/blog` header (copies `<origin>/blog/rss.xml` to clipboard, matching the mono/link-underline style and copy-button feedback pattern used elsewhere). Lint clean, build passes.